### PR TITLE
fix: stop re-prompting update after user skips or upgrades

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -13,8 +13,9 @@ pub struct Settings {
     pub enabled_managers: Vec<String>,
     pub border_style: String, // "Plain", "Rounded", "Double", "Thick"
     pub spinner_type: String, // "Dots", "Bars", "Pulse", "Classic"
-    /// Version the user explicitly skipped. Cleared automatically when a
-    /// genuinely newer release appears, so the prompt resurfaces then.
+    /// Version the user explicitly skipped. Ignored while the same tag is
+    /// latest; cleared from config when a genuinely newer release is detected,
+    /// so the prompt resurfaces automatically for new updates.
     pub skipped_update_version: Option<String>,
 }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -13,6 +13,9 @@ pub struct Settings {
     pub enabled_managers: Vec<String>,
     pub border_style: String, // "Plain", "Rounded", "Double", "Thick"
     pub spinner_type: String, // "Dots", "Bars", "Pulse", "Classic"
+    /// Version the user explicitly skipped. Cleared automatically when a
+    /// genuinely newer release appears, so the prompt resurfaces then.
+    pub skipped_update_version: Option<String>,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
@@ -62,6 +65,7 @@ impl Default for Config {
                 enabled_managers: vec!["pacman".to_string(), "yay".to_string(), "brew".to_string(), "apt".to_string()],
                 border_style: "Rounded".to_string(),
                 spinner_type: "Dots".to_string(),
+                skipped_update_version: None,
             },
             keys: Keys {
                 quit: "q".to_string(),

--- a/src/ui/app.rs
+++ b/src/ui/app.rs
@@ -49,7 +49,6 @@ pub struct App {
     pub show_help: bool,
     pub update_prompt: Option<(String, String)>, // (version, url)
     pub update_selected_yes: bool,
-    pub should_update: Option<String>, // if user said yes, url to update
     pub spinner_tick: u8,
     pub manager: Arc<Box<dyn managers::PackageManager>>,
     pub config: crate::config::Config,
@@ -79,8 +78,9 @@ impl App {
         
         // Spawn parallel update check if enabled
         if config.settings.auto_update_check {
+            let skipped = config.settings.skipped_update_version.clone();
             thread::spawn(move || {
-                let res = crate::updater::check_for_updates();
+                let res = crate::updater::check_for_updates(skipped.as_deref());
                 let _ = update_tx.send(res);
             });
         }
@@ -111,7 +111,6 @@ impl App {
             show_help: false,
             update_prompt: None,
             update_selected_yes: true,
-            should_update: None,
             spinner_tick: 0,
             manager,
             config,
@@ -447,7 +446,7 @@ impl App {
             }
 
             // check for update prompt response
-            if self.update_prompt.is_none() && self.should_update.is_none() {
+            if self.update_prompt.is_none() {
                 if let Ok(Some(update)) = self.update_rx.try_recv() {
                     self.update_prompt = Some(update);
                 }
@@ -526,7 +525,10 @@ impl App {
                                         }
                                     }
                                     KeyCode::Esc | KeyCode::Char('q') => {
-                                        self.update_prompt = None;
+                                        if let Some((version, _)) = self.update_prompt.take() {
+                                            self.config.settings.skipped_update_version = Some(version);
+                                            let _ = self.config.save();
+                                        }
                                     }
                                     _ => {}
                                 }

--- a/src/ui/app.rs
+++ b/src/ui/app.rs
@@ -448,6 +448,12 @@ impl App {
             // check for update prompt response
             if self.update_prompt.is_none() {
                 if let Ok(Some(update)) = self.update_rx.try_recv() {
+                    // A genuinely newer release arrived — clear any stale skip
+                    // entry so the config stays tidy.
+                    if self.config.settings.skipped_update_version.is_some() {
+                        self.config.settings.skipped_update_version = None;
+                        let _ = self.config.save();
+                    }
                     self.update_prompt = Some(update);
                 }
             }

--- a/src/updater.rs
+++ b/src/updater.rs
@@ -16,7 +16,7 @@ struct Asset {
     browser_download_url: String,
 }
 
-pub fn check_for_updates() -> Option<(String, String)> {
+pub fn check_for_updates(skipped_version: Option<&str>) -> Option<(String, String)> {
     let client = reqwest::blocking::Client::builder()
         .user_agent(USER_AGENT)
         .timeout(std::time::Duration::from_secs(2))
@@ -28,6 +28,13 @@ pub fn check_for_updates() -> Option<(String, String)> {
 
     let current_version = env!("CARGO_PKG_VERSION");
     let latest_version = release.tag_name.trim_start_matches('v');
+
+    // If the user explicitly skipped this exact version, don't prompt again.
+    // Once a genuinely newer release appears is_newer will be true for the
+    // new version and the skipped entry becomes stale automatically.
+    if skipped_version.map_or(false, |s| s == latest_version) {
+        return None;
+    }
 
     if is_newer(latest_version, current_version) {
         // Find asset for current platform


### PR DESCRIPTION
Fixes #24.

## Root causes fixed

Three bugs caused TRX to keep showing the update dialog on every launch:

### 1. Dead `should_update` field removed
`App::should_update: Option<String>` was initialized to `None` and never written to anywhere. The guard `&& self.should_update.is_none()` was always `true` (dead code). Field and guard removed.

### 2. Skip is now persisted across restarts
Pressing **Esc** or **q** on the update prompt previously only dismissed the dialog in-memory. On the next launch the same GitHub release was fetched and the user was prompted again, forever.

**Fix:** when the user dismisses the prompt, the skipped version string is written to `~/.config/trx/config.toml` as `settings.skipped_update_version`. The value survives restarts. When a genuinely newer tag appears on GitHub the stored version no longer matches, so the prompt resurfaces automatically — users are never silently stuck on an old version.

### 3. `check_for_updates` skips early for persisted skip
The signature changed from `check_for_updates()` → `check_for_updates(skipped_version: Option<&str>)`. The background thread is handed the persisted value at startup and returns `None` immediately if the latest release matches — so the channel event is never sent and the UI never receives a stale prompt.

## Files changed

| File | Change |
|------|--------|
| `src/config.rs` | Added `skipped_update_version: Option<String>` to `Settings` (defaults to `None`) |
| `src/updater.rs` | New `skipped_version` param; early-return when it matches latest |
| `src/ui/app.rs` | Removed dead field, persists skip on Esc/q, passes skipped version to thread |

## Testing

```bash
cargo build          # compiles clean, zero warnings
```

Manual test flow:
1. Build a dev binary where current version < latest tag
2. Launch → update prompt appears
3. Press **Esc** → inspect `~/.config/trx/config.toml`: `skipped_update_version` field is set
4. Relaunch → no prompt (skipped version matches latest)
5. Simulate a newer tag → prompt reappears