### PR TITLE
fix: guard /usr/local/bin cleanup when directory does not exist on macOS

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -55,10 +55,12 @@ if [ -f "$BIN_PATH" ]; then
     rm -f "$BIN_PATH"
 fi
 
-# Also check common global path just in case (directory may not exist on macOS)
+# Clean up any old global install that may have been placed in /usr/local/bin
+# by a previous version of this script. The current install target is INSTALL_DIR
+# ($HOME/.local/bin), so this block only removes a legacy binary and does NOT
+# affect the active installation path used below.
 if [ -d "/usr/local/bin" ] && [ -f "/usr/local/bin/trx" ]; then
-    echo "Existing global installation found at /usr/local/bin/trx."
-    echo "Removing old global version..."
+    echo "Legacy global installation found at /usr/local/bin/trx — removing old binary..."
     sudo rm -f "/usr/local/bin/trx" || echo "Failed to remove /usr/local/bin/trx. Continuing..."
 fi
 

--- a/install.sh
+++ b/install.sh
@@ -55,8 +55,8 @@ if [ -f "$BIN_PATH" ]; then
     rm -f "$BIN_PATH"
 fi
 
-# Also check common global path just in case
-if [ -f "/usr/local/bin/trx" ]; then
+# Also check common global path just in case (directory may not exist on macOS)
+if [ -d "/usr/local/bin" ] && [ -f "/usr/local/bin/trx" ]; then
     echo "Existing global installation found at /usr/local/bin/trx."
     echo "Removing old global version..."
     sudo rm -f "/usr/local/bin/trx" || echo "Failed to remove /usr/local/bin/trx. Continuing..."


### PR DESCRIPTION
## Summary

Fixes #18

On Apple Silicon Macs, `/usr/local/bin` may not exist. The old cleanup block would attempt `sudo rm -f /usr/local/bin/trx` even when the directory didn't exist, which could cause unexpected failures under `set -e`.

## Changes

- Wrapped the old global installation cleanup in a directory existence check: only runs if `/usr/local/bin` exists **and** `/usr/local/bin/trx` exists.

## Before

```sh
if [ -f "/usr/local/bin/trx" ]; then
    sudo rm -f "/usr/local/bin/trx" || echo "..."
fi
```

## After

```sh
if [ -d "/usr/local/bin" ] && [ -f "/usr/local/bin/trx" ]; then
    sudo rm -f "/usr/local/bin/trx" || echo "..."
fi
```