### PR TITLE
feat: add update selected packages (u) and manual update check (C) keybindings

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -24,6 +24,7 @@ pub struct Keys {
     pub quit: String,
     pub install: String,
     pub remove: String,
+    pub update: String,
     pub search_edit: String,
     pub toggle_select: String,
     pub tab_next: String,
@@ -31,6 +32,7 @@ pub struct Keys {
     pub system_upgrade: String,
     pub refresh_db: String,
     pub help: String,
+    pub check_update: String,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
@@ -72,6 +74,7 @@ impl Default for Config {
                 quit: "q".to_string(),
                 install: "i".to_string(),
                 remove: "x".to_string(),
+                update: "u".to_string(),
                 search_edit: "e".to_string(),
                 toggle_select: " ".to_string(),
                 tab_next: "Tab".to_string(),
@@ -79,6 +82,7 @@ impl Default for Config {
                 system_upgrade: "U".to_string(),
                 refresh_db: "R".to_string(),
                 help: "?".to_string(),
+                check_update: "C".to_string(),
             },
             theme: Theme {
                 border_color: "blue".to_string(),

--- a/src/main.rs
+++ b/src/main.rs
@@ -41,9 +41,11 @@ fn main() -> Result<()> {
                 println!("  {:<16} Toggle package selection or settings", if keys.toggle_select == " " { "Space".to_string() } else { keys.toggle_select.clone() });
                 println!("  {:<16} Install selected packages", keys.install);
                 println!("  {:<16} Remove selected packages", keys.remove);
+                println!("  {:<16} Update selected packages", keys.update);
                 println!("  {:<16} Full system upgrade", keys.system_upgrade);
                 println!("  {:<16} Refresh package databases", keys.refresh_db);
                 println!("  {:<16} Toggle help overlay", keys.help);
+                println!("  {:<16} Check for trx binary updates", keys.check_update);
                 println!("\nMouse Support:");
                 println!("  Full navigation, tab switching, and scrolling are supported.");
                 return Ok(());

--- a/src/managers/apt.rs
+++ b/src/managers/apt.rs
@@ -173,6 +173,21 @@ impl PackageManager for AptManager {
         Ok(())
     }
 
+    fn update_packages(
+        &self,
+        terminal: &mut DefaultTerminal,
+        pkgs: &HashSet<String>,
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        if pkgs.is_empty() {
+            return Ok(());
+        }
+        let mut args = vec!["apt", "install", "--only-upgrade", "-y"];
+        let pkg_refs: Vec<&str> = pkgs.iter().map(|s| s.as_str()).collect();
+        args.extend(pkg_refs);
+        crate::execute_external_command(terminal, "sudo", &args)?;
+        Ok(())
+    }
+
     fn system_upgrade(
         &self,
         terminal: &mut DefaultTerminal,

--- a/src/managers/arch.rs
+++ b/src/managers/arch.rs
@@ -132,6 +132,27 @@ impl PackageManager for ArchManager {
         pacman::pacman_remove(terminal, pkgs)
     }
 
+    fn update_packages(&self, terminal: &mut DefaultTerminal, pkgs: &HashSet<String>) -> Result<(), Box<dyn std::error::Error>> {
+        let mut pacman_pkgs = HashSet::new();
+        let mut aur_pkgs = HashSet::new();
+
+        for name in pkgs {
+            if name.starts_with("aur/") {
+                aur_pkgs.insert(name.clone());
+            } else {
+                pacman_pkgs.insert(name.clone());
+            }
+        }
+
+        if !pacman_pkgs.is_empty() {
+            pacman::pacman_install(terminal, &pacman_pkgs)?;
+        }
+        if !aur_pkgs.is_empty() {
+            yay::aur_install(terminal, &aur_pkgs, &self.aur_helper)?;
+        }
+        Ok(())
+    }
+
     fn system_upgrade(&self, terminal: &mut DefaultTerminal) -> Result<(), Box<dyn std::error::Error>> {
         let config = crate::config::Config::load();
         let enabled = &config.settings.enabled_managers;

--- a/src/managers/brew.rs
+++ b/src/managers/brew.rs
@@ -205,6 +205,21 @@ impl PackageManager for BrewManager {
         Ok(())
     }
 
+    fn update_packages(
+        &self,
+        terminal: &mut DefaultTerminal,
+        pkgs: &HashSet<String>,
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        if pkgs.is_empty() {
+            return Ok(());
+        }
+        let mut args = vec!["upgrade"];
+        let pkg_refs: Vec<&str> = pkgs.iter().map(|s| s.as_str()).collect();
+        args.extend(pkg_refs);
+        crate::execute_external_command(terminal, "brew", &args)?;
+        Ok(())
+    }
+
     fn system_upgrade(
         &self,
         terminal: &mut DefaultTerminal,

--- a/src/managers/mod.rs
+++ b/src/managers/mod.rs
@@ -26,6 +26,7 @@ pub trait PackageManager: Send + Sync {
     fn get_details(&self, pkg: &str, provider: &str) -> Option<HashMap<String, String>>;
     fn install(&self, terminal: &mut DefaultTerminal, pkgs: &HashSet<String>) -> Result<(), Box<dyn std::error::Error>>;
     fn remove(&self, terminal: &mut DefaultTerminal, pkgs: &HashSet<String>) -> Result<(), Box<dyn std::error::Error>>;
+    fn update_packages(&self, terminal: &mut DefaultTerminal, pkgs: &HashSet<String>) -> Result<(), Box<dyn std::error::Error>>;
     fn system_upgrade(&self, terminal: &mut DefaultTerminal) -> Result<(), Box<dyn std::error::Error>>;
     fn refresh_databases(&self, terminal: &mut DefaultTerminal) -> Result<(), Box<dyn std::error::Error>>;
 }
@@ -101,6 +102,13 @@ impl PackageManager for CombinedManager {
     fn remove(&self, terminal: &mut DefaultTerminal, pkgs: &HashSet<String>) -> Result<(), Box<dyn std::error::Error>> {
         for m in &self.managers {
             m.remove(terminal, pkgs)?;
+        }
+        Ok(())
+    }
+
+    fn update_packages(&self, terminal: &mut DefaultTerminal, pkgs: &HashSet<String>) -> Result<(), Box<dyn std::error::Error>> {
+        for m in &self.managers {
+            m.update_packages(terminal, pkgs)?;
         }
         Ok(())
     }

--- a/src/ui/app.rs
+++ b/src/ui/app.rs
@@ -60,6 +60,7 @@ pub struct App {
     result_rx: Receiver<(String, Vec<Package>)>,
     details_tx: Sender<DetailsState>,
     details_rx: Receiver<DetailsState>,
+    update_tx: Sender<Option<(String, String)>>,
     update_rx: Receiver<Option<(String, String)>>,
     last_input_time: Instant,
     pending_search: bool,
@@ -79,9 +80,10 @@ impl App {
         // Spawn parallel update check if enabled
         if config.settings.auto_update_check {
             let skipped = config.settings.skipped_update_version.clone();
+            let tx = update_tx.clone();
             thread::spawn(move || {
                 let res = crate::updater::check_for_updates(skipped.as_deref());
-                let _ = update_tx.send(res);
+                let _ = tx.send(res);
             });
         }
 
@@ -124,6 +126,7 @@ impl App {
             result_rx,
             details_tx,
             details_rx,
+            update_tx,
             update_rx,
             last_input_time: Instant::now(),
             pending_search: false,
@@ -246,6 +249,33 @@ impl App {
         }
 
         Ok(())
+    }
+
+    fn run_update_command(
+        &self,
+        terminal: &mut DefaultTerminal,
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        // Update selected packages; if none are selected, update the highlighted package.
+        let mut to_update = self.selected_names.clone();
+        if to_update.is_empty() {
+            if let Some(pkg) = self.packages.get(self.selected) {
+                to_update.insert(pkg.name.clone());
+            }
+        }
+        if !to_update.is_empty() {
+            self.manager.update_packages(terminal, &to_update)?;
+        }
+        Ok(())
+    }
+
+    fn trigger_manual_update_check(&mut self) {
+        self.set_popup("Checking for updates...".to_string(), ratatui::style::Color::Cyan);
+        let tx = self.update_tx.clone();
+        thread::spawn(move || {
+            // Pass None to ignore the skipped-version filter for manual checks.
+            let res = crate::updater::check_for_updates(None);
+            let _ = tx.send(res);
+        });
     }
 
     fn switch_tab(&mut self) {
@@ -590,6 +620,16 @@ impl App {
                                     self.installed_packages = self.manager.get_installed();
                                     if let Tab::Installed = self.current_tab {
                                         self.reset_tab_state();
+                                    }
+                                } else if is_key(key.code, &keys.update) {
+                                    let _ = self.run_update_command(terminal);
+                                    self.installed_packages = self.manager.get_installed();
+                                    if let Tab::Updates = self.current_tab {
+                                        self.reset_tab_state();
+                                    }
+                                } else if is_key(key.code, &keys.check_update) {
+                                    if self.update_prompt.is_none() {
+                                        self.trigger_manual_update_check();
                                     }
                                 } else if is_key(key.code, &keys.system_upgrade) {
                                     let _ = self.manager.system_upgrade(terminal);


### PR DESCRIPTION
## Summary

Fixes #5, #14

Two new keybindings in one PR.

---

### Issue #5 — Update Package Functionality (`u` key)

A new `update` keybinding (default: `u`) upgrades the currently selected or highlighted packages without triggering a full system upgrade:

| Manager | Command |
|---------|---------|
| pacman | `sudo pacman -S --needed <pkgs>` |
| yay/AUR | `yay -S --needed <pkgs>` |
| brew | `brew upgrade <pkgs>` |
| apt | `sudo apt install --only-upgrade -y <pkgs>` |

If no packages are checked with Space, the currently highlighted package is updated. After updating, the installed-packages cache and Updates tab are refreshed.

### Issue #14 — Manual Update Check (`C` key)

A new `check_update` keybinding (default: `C`) manually triggers a check for new trx binary releases on GitHub, regardless of the `auto_update_check` setting. A "Checking for updates..." popup appears while the check is in flight. The skipped-version filter is bypassed for manual checks, so the prompt always shows if a newer release is found.

### Implementation

- `update` and `check_update` added to the `Keys` config struct (fully configurable in `config.toml`)
- `update_packages(terminal, pkgs)` added to the `PackageManager` trait and implemented in all four backends
- `update_tx` stored in `App` to allow re-using the existing update-response channel for manual triggers
- `--help` CLI output updated with the new keybindings
