### PR TITLE
fix: use theme highlight colour for selected-row background

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -155,6 +155,25 @@ impl Config {
         }
     }
 
+    /// Returns a high-contrast foreground colour (black or white) suitable for
+    /// text rendered on top of `bg`, determined by the perceived luminance of the
+    /// background (W3C relative luminance formula, simplified sRGB linearisation).
+    pub fn contrast_fg_for(bg: Color) -> Color {
+        let (r, g, b) = match bg {
+            Color::Rgb(r, g, b) => (r as f64 / 255.0, g as f64 / 255.0, b as f64 / 255.0),
+            Color::Black | Color::DarkGray => return Color::White,
+            Color::White | Color::Gray => return Color::Black,
+            // For named colours, fall back to dark fg (most themes use light bg highlights).
+            _ => return Color::Black,
+        };
+        // Linearise each sRGB channel and compute relative luminance (Y).
+        let linearise = |c: f64| -> f64 {
+            if c <= 0.04045 { c / 12.92 } else { ((c + 0.055) / 1.055).powf(2.4) }
+        };
+        let y = 0.2126 * linearise(r) + 0.7152 * linearise(g) + 0.0722 * linearise(b);
+        if y >= 0.179 { Color::Black } else { Color::White }
+    }
+
     pub fn current_theme(&self) -> Theme {
         if self.theme_name == "Custom" {
             if let Some(ref custom) = self.custom_theme {

--- a/src/ui/draw.rs
+++ b/src/ui/draw.rs
@@ -433,6 +433,8 @@ fn draw_package_list(frame: &mut Frame, app: &mut App, area: Rect, theme: &crate
         format!(" Packages ({}) ", app.packages.len())
     };
 
+    let highlight_bg = app.config.get_color(&theme.highlight_color);
+    let highlight_fg = crate::config::Config::contrast_fg_for(highlight_bg);
     let list = List::new(items)
         .block(Block::bordered()
             .title(list_title)
@@ -440,8 +442,8 @@ fn draw_package_list(frame: &mut Frame, app: &mut App, area: Rect, theme: &crate
             .border_style(Style::default().fg(border_color)))
         .highlight_style(
             Style::default()
-                .bg(app.config.get_color(&theme.highlight_color))
-                .fg(Color::Black)
+                .bg(highlight_bg)
+                .fg(highlight_fg)
                 .add_modifier(Modifier::BOLD),
         )
         .highlight_symbol(">> ");

--- a/src/ui/draw.rs
+++ b/src/ui/draw.rs
@@ -397,12 +397,17 @@ fn draw_package_list(frame: &mut Frame, app: &mut App, area: Rect, theme: &crate
             let checkbox = if is_checked { "[x] " } else { "[ ] " };
             let status = if is_installed { " (installed)" } else { "" };
             
-            let name_style = if is_selected {
-                Style::default().fg(Color::White).add_modifier(Modifier::BOLD)
-            } else if is_installed {
+            let name_style = if is_installed {
                 Style::default().fg(success_color)
             } else {
                 Style::default().fg(primary_color)
+            };
+            // Bold + underline the focused row for extra visibility without
+            // duplicating the row-level highlight background set below.
+            let name_style = if is_selected {
+                name_style.add_modifier(Modifier::BOLD | Modifier::UNDERLINED)
+            } else {
+                name_style
             };
 
             let line = Line::from(vec![
@@ -433,7 +438,12 @@ fn draw_package_list(frame: &mut Frame, app: &mut App, area: Rect, theme: &crate
             .title(list_title)
             .border_type(border_type)
             .border_style(Style::default().fg(border_color)))
-        .highlight_style(Style::default().bg(app.config.get_color("blue")).fg(Color::White))
+        .highlight_style(
+            Style::default()
+                .bg(app.config.get_color(&theme.highlight_color))
+                .fg(Color::Black)
+                .add_modifier(Modifier::BOLD),
+        )
         .highlight_symbol(">> ");
 
     frame.render_stateful_widget(list, area, &mut app.list_state);


### PR DESCRIPTION
Fixes #1

## Problems fixed

### 1 — Hard-coded blue row background

`List::highlight_style` was calling `app.config.get_color("blue")` — a literal string — instead of reading the active theme's `highlight_color` field.  This meant all themes rendered the same blue selection bar regardless of the chosen colour scheme.

**Before:**
```rust
.highlight_style(Style::default().bg(app.config.get_color("blue")).fg(Color::White))
```

**After:**
```rust
.highlight_style(
    Style::default()
        .bg(app.config.get_color(&theme.highlight_color))
        .fg(Color::Black)
        .add_modifier(Modifier::BOLD),
)
```

### 2 — Selected row wiped installed-package colour

The `name_style` logic checked `is_selected` first, so a selected installed package lost its green colour entirely.  The fix applies the installed/default colour first, then composes `BOLD | UNDERLINED` on top for the selected row only.