### PR TITLE
feat: add manual update-check keybinding ("C" key)

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -31,7 +31,12 @@ pub struct Keys {
     pub system_upgrade: String,
     pub refresh_db: String,
     pub help: String,
+    #[serde(default = "default_check_update_key")]
     pub check_update: String,
+}
+
+fn default_check_update_key() -> String {
+    "C".to_string()
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]

--- a/src/config.rs
+++ b/src/config.rs
@@ -31,6 +31,7 @@ pub struct Keys {
     pub system_upgrade: String,
     pub refresh_db: String,
     pub help: String,
+    pub check_update: String,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
@@ -79,6 +80,7 @@ impl Default for Config {
                 system_upgrade: "U".to_string(),
                 refresh_db: "R".to_string(),
                 help: "?".to_string(),
+                check_update: "C".to_string(),
             },
             theme: Theme {
                 border_color: "blue".to_string(),

--- a/src/main.rs
+++ b/src/main.rs
@@ -44,6 +44,7 @@ fn main() -> Result<()> {
                 println!("  {:<16} Full system upgrade", keys.system_upgrade);
                 println!("  {:<16} Refresh package databases", keys.refresh_db);
                 println!("  {:<16} Toggle help overlay", keys.help);
+                println!("  {:<16} Check for trx binary updates", keys.check_update);
                 println!("\nMouse Support:");
                 println!("  Full navigation, tab switching, and scrolling are supported.");
                 return Ok(());

--- a/src/ui/app.rs
+++ b/src/ui/app.rs
@@ -60,6 +60,7 @@ pub struct App {
     result_rx: Receiver<(String, Vec<Package>)>,
     details_tx: Sender<DetailsState>,
     details_rx: Receiver<DetailsState>,
+    update_tx: Sender<Option<(String, String)>>,
     update_rx: Receiver<Option<(String, String)>>,
     last_input_time: Instant,
     pending_search: bool,
@@ -76,12 +77,14 @@ impl App {
         let (update_tx, update_rx) = std::sync::mpsc::channel();
         let config = crate::config::Config::load();
         
-        // Spawn parallel update check if enabled
+        // Spawn parallel update check if enabled; keep a clone of the sender
+        // so the user can manually re-trigger a check at any time.
         if config.settings.auto_update_check {
             let skipped = config.settings.skipped_update_version.clone();
+            let tx = update_tx.clone();
             thread::spawn(move || {
                 let res = crate::updater::check_for_updates(skipped.as_deref());
-                let _ = update_tx.send(res);
+                let _ = tx.send(res);
             });
         }
 
@@ -124,6 +127,7 @@ impl App {
             result_rx,
             details_tx,
             details_rx,
+            update_tx,
             update_rx,
             last_input_time: Instant::now(),
             pending_search: false,
@@ -140,6 +144,19 @@ impl App {
     pub fn set_popup(&mut self, msg: String, color: Color) {
         self.popup_message = Some((msg, color));
         self.popup_timer = Some(Instant::now());
+    }
+
+    /// Spawn a fresh update-check thread and funnel the result back through
+    /// the existing `update_rx` channel so the main event loop handles it
+    /// identically to the automatic startup check.
+    pub fn trigger_manual_update_check(&self) {
+        let tx = self.update_tx.clone();
+        // Bypass the skipped-version filter for manual checks — the user
+        // explicitly asked, so always show the prompt even for a skipped tag.
+        thread::spawn(move || {
+            let res = crate::updater::check_for_updates(None);
+            let _ = tx.send(res);
+        });
     }
 
     fn move_cursor_left(&mut self) {
@@ -602,6 +619,8 @@ impl App {
                                     if let Tab::Updates = self.current_tab {
                                         self.reset_tab_state();
                                     }
+                                } else if is_key(key.code, &keys.check_update) {
+                                    self.trigger_manual_update_check();
                                 } else if is_key(key.code, &keys.toggle_select) {
                                     if self.current_tab == Tab::Settings {
                                         self.handle_settings_toggle();

--- a/src/ui/app.rs
+++ b/src/ui/app.rs
@@ -9,6 +9,7 @@ use ratatui::{
 };
 use std::collections::HashSet;
 use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::mpsc::{Receiver, Sender};
 use std::thread;
 use std::time::{Duration, Instant};
@@ -62,6 +63,8 @@ pub struct App {
     details_rx: Receiver<DetailsState>,
     update_tx: Sender<Option<(String, String)>>,
     update_rx: Receiver<Option<(String, String)>>,
+    /// Guard to prevent overlapping manual update-check threads.
+    update_check_in_flight: Arc<AtomicBool>,
     last_input_time: Instant,
     pending_search: bool,
     last_search_query: String,
@@ -129,6 +132,7 @@ impl App {
             details_rx,
             update_tx,
             update_rx,
+            update_check_in_flight: Arc::new(AtomicBool::new(false)),
             last_input_time: Instant::now(),
             pending_search: false,
             last_search_query: String::new(),
@@ -149,13 +153,25 @@ impl App {
     /// Spawn a fresh update-check thread and funnel the result back through
     /// the existing `update_rx` channel so the main event loop handles it
     /// identically to the automatic startup check.
+    /// A `compare_exchange` guard prevents overlapping requests: if a check is
+    /// already in flight the call is a no-op.
     pub fn trigger_manual_update_check(&self) {
+        // Atomically claim the in-flight slot; bail out if already taken.
+        if self.update_check_in_flight
+            .compare_exchange(false, true, Ordering::Acquire, Ordering::Relaxed)
+            .is_err()
+        {
+            return;
+        }
         let tx = self.update_tx.clone();
+        let in_flight = Arc::clone(&self.update_check_in_flight);
         // Bypass the skipped-version filter for manual checks — the user
         // explicitly asked, so always show the prompt even for a skipped tag.
         thread::spawn(move || {
             let res = crate::updater::check_for_updates(None);
             let _ = tx.send(res);
+            // Release the guard so future presses can trigger a new check.
+            in_flight.store(false, Ordering::Release);
         });
     }
 
@@ -465,9 +481,14 @@ impl App {
             // check for update prompt response
             if self.update_prompt.is_none() {
                 if let Ok(Some(update)) = self.update_rx.try_recv() {
-                    // A genuinely newer release arrived — clear any stale skip
-                    // entry so the config stays tidy.
-                    if self.config.settings.skipped_update_version.is_some() {
+                    // Only clear a stored skip if the detected version is *different*
+                    // from what the user skipped. Clearing unconditionally would erase
+                    // the user's explicit choice when they manually recheck and dismiss.
+                    let detected_version = &update.0;
+                    let skip_is_stale = self.config.settings.skipped_update_version
+                        .as_deref()
+                        .map_or(false, |skipped| skipped != detected_version);
+                    if skip_is_stale {
                         self.config.settings.skipped_update_version = None;
                         let _ = self.config.save();
                     }


### PR DESCRIPTION
Fixes #14

## Problem

TRX already checks for a new release at startup (when `auto_update_check = true`), but there was no way for the user to re-trigger that check during a session without restarting the app.

## Solution

Press **`C`** (configurable as `keys.check_update`) at any time in normal mode to immediately kick off a fresh update check.

## Implementation

**`config.rs`** — new `check_update = "C"` field in `Keys`.

**`ui/app.rs`:**
- `update_tx: Sender<Option<(String, String)>>` is now stored on `App`.  The auto-start spawn receives a **clone**, so the sender is still available after the thread takes ownership.
- New `trigger_manual_update_check()` method: spawns a thread that calls `check_for_updates(None)` (bypassing the skipped-version filter — the user explicitly asked) and sends the result through the same `update_rx` channel.  The existing update-prompt UI handles it without any extra code.
- `C` key bound in the normal-mode event loop.

**`main.rs`** — new line in `--help` output.