### PR TITLE
perf: parallelize package parsing

### DIFF
--- a/src/managers/apt.rs
+++ b/src/managers/apt.rs
@@ -1,5 +1,6 @@
 use crate::managers::{Package, PackageManager};
 use ratatui::DefaultTerminal;
+use rayon::prelude::*;
 use std::collections::{HashMap, HashSet};
 use std::process::Command;
 
@@ -18,8 +19,9 @@ impl PackageManager for AptManager {
 
         if let Some(output) = output {
             let stdout = String::from_utf8_lossy(&output.stdout);
-            stdout
-                .lines()
+            let lines: Vec<&str> = stdout.lines().collect();
+            lines
+                .par_iter()
                 .filter_map(|line| {
                     let parts: Vec<&str> = line.splitn(2, " - ").collect();
                     if !parts.is_empty() {
@@ -63,8 +65,9 @@ impl PackageManager for AptManager {
 
         if let Some(output) = output {
             let stdout = String::from_utf8_lossy(&output.stdout);
-            stdout
-                .lines()
+            let lines: Vec<&str> = stdout.lines().collect();
+            lines
+                .par_iter()
                 .filter_map(|line| {
                     let parts: Vec<&str> = line.split('\t').collect();
                     if parts.len() >= 2 {
@@ -90,9 +93,9 @@ impl PackageManager for AptManager {
 
         if let Some(output) = output {
             let stdout = String::from_utf8_lossy(&output.stdout);
-            stdout
-                .lines()
-                .skip(1)
+            let lines: Vec<&str> = stdout.lines().skip(1).collect();
+            lines
+                .par_iter()
                 .filter_map(|line| {
                     let parts: Vec<&str> = line.split('/').collect();
                     if !parts.is_empty() {

--- a/src/managers/brew.rs
+++ b/src/managers/brew.rs
@@ -1,5 +1,6 @@
 use crate::managers::{Package, PackageManager, SEARCH_CACHE};
 use ratatui::DefaultTerminal;
+use rayon::prelude::*;
 use std::collections::{HashMap, HashSet};
 use std::process::Command;
 
@@ -55,7 +56,7 @@ impl PackageManager for BrewManager {
         let info_map = fetch_brew_info_batch(&names);
 
         let mut results: Vec<Package> = names
-            .iter()
+            .par_iter()
             .map(|name| {
                 let score = crate::fuzzy::fuzzy_match(query, name);
                 if let Some((version, description)) = info_map.get(name.as_str()) {
@@ -96,8 +97,9 @@ impl PackageManager for BrewManager {
 
         if let Some(output) = output {
             let stdout = String::from_utf8_lossy(&output.stdout);
-            stdout
-                .lines()
+            let lines: Vec<&str> = stdout.lines().collect();
+            lines
+                .par_iter()
                 .filter_map(|l| l.split_whitespace().next().map(|s| s.to_string()))
                 .collect()
         } else {
@@ -110,8 +112,9 @@ impl PackageManager for BrewManager {
 
         if let Some(output) = output {
             let stdout = String::from_utf8_lossy(&output.stdout);
-            stdout
-                .lines()
+            let lines: Vec<&str> = stdout.lines().collect();
+            lines
+                .par_iter()
                 .filter_map(|line| {
                     let mut parts = line.split_whitespace();
                     let name = parts.next()?.to_string();
@@ -139,8 +142,9 @@ impl PackageManager for BrewManager {
 
         if let Some(output) = output {
             let stdout = String::from_utf8_lossy(&output.stdout);
-            stdout
-                .lines()
+            let lines: Vec<&str> = stdout.lines().collect();
+            lines
+                .par_iter()
                 .filter_map(|line| {
                     // format: "name (installed_version) < latest_version"
                     let mut parts = line.splitn(2, ' ');

--- a/src/managers/mod.rs
+++ b/src/managers/mod.rs
@@ -5,6 +5,7 @@ pub mod pacman;
 pub mod yay;
 
 use ratatui::DefaultTerminal;
+use rayon::prelude::*;
 use std::collections::{HashMap, HashSet};
 use std::sync::{Arc, Mutex};
 
@@ -234,37 +235,69 @@ lazy_static::lazy_static! {
 }
 
 pub fn parse_alternating_lines(lines: &[&str], manager: String, query: &str) -> Vec<Package> {
-    let mut res = Vec::new();
-    let mut i = 0;
+    let mut res: Vec<Package> = lines
+        .par_chunks(2)
+        .filter_map(|chunk| {
+            let [first_line, second_line] = chunk else {
+                return None;
+            };
 
-    while i + 1 < lines.len() {
-        let first_line = lines[i];
-        let second_line = lines[i + 1];
-
-        let parts: Vec<&str> = first_line.split_whitespace().collect();
-
-        if parts.len() >= 2 {
-            let package = parts[0].to_string();
-            let version = parts[1].to_string();
+            let mut parts = first_line.split_whitespace();
+            let package = parts.next()?.to_string();
+            let version = parts.next()?.to_string();
             let description = second_line.trim().to_string();
+            let package_name = package.split('/').next_back().unwrap_or(package.as_str());
+            let score = crate::fuzzy::fuzzy_match(query, package_name);
 
-            let package_name = package.split('/').next_back().unwrap_or(&package).to_string();
-            let score = crate::fuzzy::fuzzy_match(query, &package_name);
-
-            res.push(Package {
+            (score > 0.01).then(|| Package {
                 provider: manager.clone(),
                 name: package,
                 version,
                 description,
                 score,
-            });
-        }
+            })
+        })
+        .collect();
 
-        i += 2;
-    }
-
-    res.retain(|p| p.score > 0.01);
     res.sort_by(|a, b| b.score.partial_cmp(&a.score).unwrap_or(std::cmp::Ordering::Equal));
 
     res
+}
+
+#[cfg(test)]
+mod tests {
+    use super::parse_alternating_lines;
+
+    #[test]
+    fn alternating_parser_ignores_incomplete_trailing_line() {
+        let lines = [
+            "extra/ripgrep 14.1.1-1",
+            "    fast recursive search tool",
+            "extra/fd 10.2.0-1",
+        ];
+
+        let packages = parse_alternating_lines(&lines, "pacman".into(), "ripgrep");
+
+        assert_eq!(packages.len(), 1);
+        assert_eq!(packages[0].name, "extra/ripgrep");
+        assert_eq!(packages[0].version, "14.1.1-1");
+        assert_eq!(packages[0].description, "fast recursive search tool");
+        assert_eq!(packages[0].provider, "pacman");
+    }
+
+    #[test]
+    fn alternating_parser_sorts_matching_packages_by_score() {
+        let lines = [
+            "extra/trx 0.1.0-1",
+            "    tui package manager",
+            "extra/trx-cli 0.1.0-1",
+            "    command line package manager",
+        ];
+
+        let packages = parse_alternating_lines(&lines, "pacman".into(), "trx");
+
+        assert_eq!(packages.len(), 2);
+        assert_eq!(packages[0].name, "extra/trx");
+        assert!(packages[0].score >= packages[1].score);
+    }
 }

--- a/src/managers/pacman.rs
+++ b/src/managers/pacman.rs
@@ -1,6 +1,7 @@
 use super::Package;
 use crate::execute_external_command;
 use ratatui::DefaultTerminal;
+use rayon::prelude::*;
 use std::collections::{HashMap, HashSet};
 
 pub fn search_pacman(search_word: &str) -> Vec<Package> {
@@ -129,8 +130,9 @@ pub fn get_installed_packages() -> HashSet<String> {
 
     if let Some(output) = output {
         let stdout = String::from_utf8_lossy(&output.stdout);
-        stdout
-            .lines()
+        let lines: Vec<&str> = stdout.lines().collect();
+        lines
+            .par_iter()
             .filter_map(|line| line.split_whitespace().next().map(|s| s.to_string()))
             .collect()
     } else {
@@ -143,8 +145,9 @@ pub fn get_installed_packages_details() -> Vec<Package> {
 
     if let Some(output) = output {
         let stdout = String::from_utf8_lossy(&output.stdout);
-        stdout
-            .lines()
+        let lines: Vec<&str> = stdout.lines().collect();
+        lines
+            .par_iter()
             .filter_map(|line| {
                 let parts: Vec<&str> = line.split_whitespace().collect();
                 if parts.len() >= 2 {
@@ -170,8 +173,9 @@ pub fn get_updates() -> Vec<Package> {
 
     if let Some(output) = output {
         let stdout = String::from_utf8_lossy(&output.stdout);
-        stdout
-            .lines()
+        let lines: Vec<&str> = stdout.lines().collect();
+        lines
+            .par_iter()
             .filter_map(|line| {
                 // format: pkgname oldver -> newver
                 let parts: Vec<&str> = line.split_whitespace().collect();

--- a/src/managers/yay.rs
+++ b/src/managers/yay.rs
@@ -1,5 +1,6 @@
 use crate::execute_external_command;
 use ratatui::DefaultTerminal;
+use rayon::prelude::*;
 use std::collections::{HashMap, HashSet};
 
 use super::Package;
@@ -37,24 +38,27 @@ pub fn search_aur(search_word: &str, _aur_helper: &str) -> Vec<Package> {
         Err(_) => return Vec::new(),
     };
 
-    let mut results = Vec::new();
-    if let Some(arr) = json["results"].as_array() {
-        for item in arr {
+    let Some(arr) = json["results"].as_array() else {
+        return Vec::new();
+    };
+
+    let mut results: Vec<Package> = arr
+        .par_iter()
+        .map(|item| {
             let name = item["Name"].as_str().unwrap_or("").to_string();
             let version = item["Version"].as_str().unwrap_or("").to_string();
             let description = item["Description"].as_str().unwrap_or("").to_string();
-
             let score = crate::fuzzy::fuzzy_match(search_word, &name);
 
-            results.push(Package {
+            Package {
                 provider: "aur".to_string(),
                 name,
                 version,
                 description,
                 score,
-            });
-        }
-    }
+            }
+        })
+        .collect();
 
     results.sort_by(|a, b| b.score.partial_cmp(&a.score).unwrap_or(std::cmp::Ordering::Equal));
     results


### PR DESCRIPTION
## What changed
- Parallelized stateless package output parsing for APT, pacman, Homebrew, and AUR search/list/update paths using the existing rayon dependency.
- Updated the shared alternating-line parser used by pacman search to parse chunks in parallel while preserving score filtering and final score ordering.
- Added unit coverage for incomplete trailing pacman output and score-sorted parser results.

## Why
Large package-manager outputs can contain thousands of lines. Parsing those lines sequentially adds avoidable CPU latency before the TUI can render results. The changed paths operate on already captured command output and do not parallelize command execution or cache mutation.

## How to test
- git diff --check

Local limitation: this Codex environment does not have cargo/rustc installed, so I could not run cargo fmt/test/build locally. The repository CI installs the Rust toolchain and should run cargo fmt, clippy, tests, audit, and build on this PR.

Closes #72