### PR TITLE
feat(security): add bubblewrap package sandbox

### DIFF
--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -22,6 +22,7 @@ General behavioral settings for the application.
 | `auto_update_check` | Boolean | `true` | Whether to check for `trx` updates on startup. |
 | `default_tab` | String | `"Search"` | The tab to display on startup (`"Search"`, `"Installed"`, or `"Updates"`). |
 | `max_search_results` | Integer | `50` | Maximum number of results to display in the search list. |
+| `sandbox` | Boolean | `false` | Linux-only opt-in Bubblewrap sandbox for install/remove subprocesses. Falls back with a warning if `bwrap` is unavailable. |
 
 ---
 
@@ -69,6 +70,7 @@ search_debounce_ms = 300
 auto_update_check = true
 default_tab = "Search"
 max_search_results = 100
+sandbox = false
 
 [keys]
 quit = "q"

--- a/src/config.rs
+++ b/src/config.rs
@@ -11,6 +11,8 @@ pub struct Settings {
     pub default_tab: String,
     pub max_search_results: usize,
     pub enabled_managers: Vec<String>,
+    #[serde(default)]
+    pub sandbox: bool,
     pub border_style: String, // "Plain", "Rounded", "Double", "Thick"
     pub spinner_type: String, // "Dots", "Bars", "Pulse", "Classic", "Arc", "Braille"
     /// Version the user explicitly skipped. Ignored while the same tag is
@@ -76,6 +78,7 @@ impl Default for Config {
                     "brew".to_string(),
                     "apt".to_string(),
                 ],
+                sandbox: false,
                 border_style: "Rounded".to_string(),
                 spinner_type: "Dots".to_string(),
                 skipped_update_version: None,

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,7 @@
 mod config;
 mod fuzzy;
 mod managers;
+mod sandbox;
 mod ui;
 mod updater;
 
@@ -62,6 +63,8 @@ fn main() -> Result<()> {
     }
 
     color_eyre::install()?;
+    let config = config::Config::load();
+    sandbox::warn_if_misconfigured(&config);
     let mut terminal = init();
     execute!(std::io::stdout(), EnableMouseCapture)?;
     let (result_tx, result_rx) = mpsc::channel();
@@ -119,4 +122,14 @@ pub fn execute_external_command(
     terminal.clear()?;
 
     Ok(())
+}
+
+pub fn execute_package_command(
+    terminal: &mut ratatui::DefaultTerminal,
+    cmd: &str,
+    args: &[&str],
+) -> Result<()> {
+    let command = sandbox::package_command(cmd, args);
+    let args_ref: Vec<&str> = command.args.iter().map(String::as_str).collect();
+    execute_external_command(terminal, &command.cmd, &args_ref)
 }

--- a/src/managers/apt.rs
+++ b/src/managers/apt.rs
@@ -145,7 +145,7 @@ impl PackageManager for AptManager {
         let mut args = vec!["apt", "install", "-y"];
         let pkg_refs: Vec<&str> = pkgs.iter().map(|s| s.as_str()).collect();
         args.extend(pkg_refs);
-        crate::execute_external_command(terminal, "sudo", &args)?;
+        crate::execute_package_command(terminal, "sudo", &args)?;
         Ok(())
     }
 
@@ -157,7 +157,7 @@ impl PackageManager for AptManager {
         let mut args = vec!["apt", "remove", "-y"];
         let pkg_refs: Vec<&str> = pkgs.iter().map(|s| s.as_str()).collect();
         args.extend(pkg_refs);
-        crate::execute_external_command(terminal, "sudo", &args)?;
+        crate::execute_package_command(terminal, "sudo", &args)?;
         Ok(())
     }
 

--- a/src/managers/brew.rs
+++ b/src/managers/brew.rs
@@ -225,7 +225,7 @@ impl PackageManager for BrewManager {
         let mut args = vec!["install"];
         let pkg_refs: Vec<&str> = pkgs.iter().map(|s| s.as_str()).collect();
         args.extend(pkg_refs);
-        crate::execute_external_command(terminal, "brew", &args)?;
+        crate::execute_package_command(terminal, "brew", &args)?;
         Ok(())
     }
 
@@ -237,7 +237,7 @@ impl PackageManager for BrewManager {
         let mut args = vec!["uninstall"];
         let pkg_refs: Vec<&str> = pkgs.iter().map(|s| s.as_str()).collect();
         args.extend(pkg_refs);
-        crate::execute_external_command(terminal, "brew", &args)?;
+        crate::execute_package_command(terminal, "brew", &args)?;
         Ok(())
     }
 

--- a/src/managers/pacman.rs
+++ b/src/managers/pacman.rs
@@ -71,7 +71,7 @@ pub fn pacman_install(
     args.extend(pure);
 
     let args_ref: Vec<&str> = args.iter().map(|x| x.as_str()).collect();
-    execute_external_command(
+    crate::execute_package_command(
         terminal,
         "sudo",
         {
@@ -100,7 +100,7 @@ pub fn pacman_remove(
     args.extend(pure);
 
     let args_ref: Vec<&str> = args.iter().map(|x| x.as_str()).collect();
-    execute_external_command(
+    crate::execute_package_command(
         terminal,
         "sudo",
         {

--- a/src/managers/yay.rs
+++ b/src/managers/yay.rs
@@ -120,7 +120,7 @@ pub fn aur_install(
     args.extend(pure);
 
     let args_ref: Vec<&str> = args.iter().map(|x| x.as_str()).collect();
-    execute_external_command(terminal, aur_helper, &args_ref)?;
+    crate::execute_package_command(terminal, aur_helper, &args_ref)?;
 
     Ok(())
 }

--- a/src/sandbox.rs
+++ b/src/sandbox.rs
@@ -1,0 +1,136 @@
+use crate::config::Config;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CommandSpec {
+    pub cmd: String,
+    pub args: Vec<String>,
+}
+
+const BWRAP_ARGS: &[&str] = &[
+    "--ro-bind",
+    "/usr",
+    "/usr",
+    "--ro-bind",
+    "/etc",
+    "/etc",
+    "--bind",
+    "/tmp",
+    "/tmp",
+    "--proc",
+    "/proc",
+    "--dev",
+    "/dev",
+    "--",
+];
+
+pub fn build_package_command(
+    cmd: &str,
+    args: &[&str],
+    sandbox_enabled: bool,
+    bwrap_available: bool,
+    target_linux: bool,
+) -> CommandSpec {
+    if !(sandbox_enabled && bwrap_available && target_linux) {
+        return CommandSpec {
+            cmd: cmd.to_string(),
+            args: args.iter().map(|arg| (*arg).to_string()).collect(),
+        };
+    }
+
+    let mut sandbox_args: Vec<String> = BWRAP_ARGS.iter().map(|arg| (*arg).to_string()).collect();
+    sandbox_args.push(cmd.to_string());
+    sandbox_args.extend(args.iter().map(|arg| (*arg).to_string()));
+
+    CommandSpec {
+        cmd: "bwrap".to_string(),
+        args: sandbox_args,
+    }
+}
+
+pub fn package_command(cmd: &str, args: &[&str]) -> CommandSpec {
+    let config = Config::load();
+    build_package_command(
+        cmd,
+        args,
+        config.settings.sandbox,
+        is_bwrap_available(),
+        cfg!(target_os = "linux"),
+    )
+}
+
+pub fn warn_if_misconfigured(config: &Config) {
+    if config.settings.sandbox && cfg!(target_os = "linux") && !is_bwrap_available() {
+        eprintln!(
+            "warning: sandbox=true but Bubblewrap (bwrap) was not found in PATH; package commands will run without sandboxing"
+        );
+    }
+}
+
+fn is_bwrap_available() -> bool {
+    if !cfg!(target_os = "linux") {
+        return false;
+    }
+
+    std::process::Command::new("bwrap").arg("--version").output().is_ok()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn leaves_command_unchanged_when_sandbox_disabled() {
+        let command =
+            build_package_command("sudo", &["apt", "install", "ripgrep"], false, true, true);
+
+        assert_eq!(command.cmd, "sudo");
+        assert_eq!(command.args, vec!["apt", "install", "ripgrep"]);
+    }
+
+    #[test]
+    fn leaves_command_unchanged_when_bwrap_is_missing() {
+        let command =
+            build_package_command("sudo", &["apt", "remove", "ripgrep"], true, false, true);
+
+        assert_eq!(command.cmd, "sudo");
+        assert_eq!(command.args, vec!["apt", "remove", "ripgrep"]);
+    }
+
+    #[test]
+    fn leaves_command_unchanged_on_non_linux_targets() {
+        let command = build_package_command("brew", &["install", "ripgrep"], true, true, false);
+
+        assert_eq!(command.cmd, "brew");
+        assert_eq!(command.args, vec!["install", "ripgrep"]);
+    }
+
+    #[test]
+    fn wraps_linux_package_command_when_enabled_and_available() {
+        let command = build_package_command("sudo", &["apt", "install", "ripgrep"], true, true, true);
+
+        assert_eq!(command.cmd, "bwrap");
+        assert_eq!(
+            command.args,
+            vec![
+                "--ro-bind",
+                "/usr",
+                "/usr",
+                "--ro-bind",
+                "/etc",
+                "/etc",
+                "--bind",
+                "/tmp",
+                "/tmp",
+                "--proc",
+                "/proc",
+                "--dev",
+                "/dev",
+                "--",
+                "sudo",
+                "apt",
+                "install",
+                "ripgrep",
+            ]
+        );
+    }
+}


### PR DESCRIPTION
## Description
Adds the opt-in Bubblewrap sandbox requested in #88.

Fixes #88
Supersedes #99, which was closed because it targeted `main`; this PR targets `dev` as requested by the maintainer.

What changed:
- added `settings.sandbox` with `#[serde(default)]` so existing config files keep loading
- added a small `sandbox` command builder that wraps install/remove subprocesses with `bwrap` only on Linux when sandboxing is enabled and `bwrap` is available
- warns at startup when `sandbox = true` on Linux but `bwrap` is missing
- routed apt, brew, pacman, and AUR helper install/remove calls through the package-command wrapper
- documented the new setting in `docs/CONFIGURATION.md`

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update

## How Has This Been Tested?
- [x] Manual/static checks: `git diff --check origin/dev...HEAD`
- [ ] `cargo test`

Local limitation: this machine does not have Rust tooling installed (`cargo`, `rustc`, and `rustfmt` are unavailable), so I could not run `cargo test` locally. I added unit tests for the command builder behavior in `src/sandbox.rs` so CI can exercise the enabled/disabled/missing-bwrap/non-Linux cases.

## Checklist:
- [x] My code follows the [Coding Guidelines](CONTRIBUTING.md#4-coding-guidelines).
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have NOT added useless AI-generated comments.
- [x] I have NOT deleted existing unrelated comments.
- [x] I have NOT modified files unrelated to this task.
- [x] I have included screenshots/recordings (for UI changes).
- [ ] My changes generate no new warnings (clippy/fmt).
- [x] I have linked the issue I am working on.

## Screenshots (if applicable)
Not applicable; this is config/subprocess hardening with no UI surface change.
