### PR TITLE
security: add optional bubblewrap sandbox

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -13,6 +13,8 @@ pub struct Settings {
     pub enabled_managers: Vec<String>,
     pub border_style: String, // "Plain", "Rounded", "Double", "Thick"
     pub spinner_type: String, // "Dots", "Bars", "Pulse", "Classic", "Arc", "Braille"
+    #[serde(default)]
+    pub sandbox: bool,
     /// Version the user explicitly skipped. Ignored while the same tag is
     /// latest; cleared from config when a genuinely newer release is detected,
     /// so the prompt resurfaces automatically for new updates.
@@ -78,6 +80,7 @@ impl Default for Config {
                 ],
                 border_style: "Rounded".to_string(),
                 spinner_type: "Dots".to_string(),
+                sandbox: false,
                 skipped_update_version: None,
             },
             keys: Keys {

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,7 @@
 mod config;
 mod fuzzy;
 mod managers;
+mod sandbox;
 mod ui;
 mod updater;
 
@@ -62,6 +63,11 @@ fn main() -> Result<()> {
     }
 
     color_eyre::install()?;
+    let config = config::Config::load();
+    if let Some(warning) = sandbox::startup_warning(config.settings.sandbox) {
+        eprintln!("{}", warning);
+    }
+
     let mut terminal = init();
     execute!(std::io::stdout(), EnableMouseCapture)?;
     let (result_tx, result_rx) = mpsc::channel();
@@ -92,14 +98,35 @@ pub fn execute_external_command(
     cmd: &str,
     args: &[&str],
 ) -> Result<()> {
+    execute_external_command_inner(terminal, cmd, args, false)
+}
+
+pub fn execute_sandboxable_external_command(
+    terminal: &mut ratatui::DefaultTerminal,
+    cmd: &str,
+    args: &[&str],
+) -> Result<()> {
+    execute_external_command_inner(terminal, cmd, args, true)
+}
+
+fn execute_external_command_inner(
+    terminal: &mut ratatui::DefaultTerminal,
+    cmd: &str,
+    args: &[&str],
+    allow_sandbox: bool,
+) -> Result<()> {
     terminal::disable_raw_mode()?;
     execute!(terminal.backend_mut(), LeaveAlternateScreen, Show, DisableMouseCapture)?;
 
+    let config = config::Config::load();
+    let (program, command_args) =
+        sandbox::command_for(cmd, args, allow_sandbox && config.settings.sandbox);
+
     println!("\n{}", "=".repeat(40));
-    println!(" RUNNING: {} {}", cmd, args.join(" "));
+    println!(" RUNNING: {} {}", program, command_args.join(" "));
     println!("{}\n", "=".repeat(40));
 
-    let status = std::process::Command::new(cmd).args(args).status();
+    let status = std::process::Command::new(&program).args(&command_args).status();
 
     println!("\n{}", "=".repeat(40));
     match status {

--- a/src/managers/apt.rs
+++ b/src/managers/apt.rs
@@ -145,7 +145,7 @@ impl PackageManager for AptManager {
         let mut args = vec!["apt", "install", "-y"];
         let pkg_refs: Vec<&str> = pkgs.iter().map(|s| s.as_str()).collect();
         args.extend(pkg_refs);
-        crate::execute_external_command(terminal, "sudo", &args)?;
+        crate::execute_sandboxable_external_command(terminal, "sudo", &args)?;
         Ok(())
     }
 
@@ -157,7 +157,7 @@ impl PackageManager for AptManager {
         let mut args = vec!["apt", "remove", "-y"];
         let pkg_refs: Vec<&str> = pkgs.iter().map(|s| s.as_str()).collect();
         args.extend(pkg_refs);
-        crate::execute_external_command(terminal, "sudo", &args)?;
+        crate::execute_sandboxable_external_command(terminal, "sudo", &args)?;
         Ok(())
     }
 

--- a/src/managers/brew.rs
+++ b/src/managers/brew.rs
@@ -225,7 +225,7 @@ impl PackageManager for BrewManager {
         let mut args = vec!["install"];
         let pkg_refs: Vec<&str> = pkgs.iter().map(|s| s.as_str()).collect();
         args.extend(pkg_refs);
-        crate::execute_external_command(terminal, "brew", &args)?;
+        crate::execute_sandboxable_external_command(terminal, "brew", &args)?;
         Ok(())
     }
 
@@ -237,7 +237,7 @@ impl PackageManager for BrewManager {
         let mut args = vec!["uninstall"];
         let pkg_refs: Vec<&str> = pkgs.iter().map(|s| s.as_str()).collect();
         args.extend(pkg_refs);
-        crate::execute_external_command(terminal, "brew", &args)?;
+        crate::execute_sandboxable_external_command(terminal, "brew", &args)?;
         Ok(())
     }
 

--- a/src/managers/pacman.rs
+++ b/src/managers/pacman.rs
@@ -1,5 +1,5 @@
 use super::Package;
-use crate::execute_external_command;
+use crate::{execute_external_command, execute_sandboxable_external_command};
 use ratatui::DefaultTerminal;
 use std::collections::{HashMap, HashSet};
 
@@ -71,7 +71,7 @@ pub fn pacman_install(
     args.extend(pure);
 
     let args_ref: Vec<&str> = args.iter().map(|x| x.as_str()).collect();
-    execute_external_command(
+    execute_sandboxable_external_command(
         terminal,
         "sudo",
         {
@@ -100,7 +100,7 @@ pub fn pacman_remove(
     args.extend(pure);
 
     let args_ref: Vec<&str> = args.iter().map(|x| x.as_str()).collect();
-    execute_external_command(
+    execute_sandboxable_external_command(
         terminal,
         "sudo",
         {

--- a/src/managers/yay.rs
+++ b/src/managers/yay.rs
@@ -1,4 +1,4 @@
-use crate::execute_external_command;
+use crate::{execute_external_command, execute_sandboxable_external_command};
 use ratatui::DefaultTerminal;
 use std::collections::{HashMap, HashSet};
 
@@ -120,7 +120,7 @@ pub fn aur_install(
     args.extend(pure);
 
     let args_ref: Vec<&str> = args.iter().map(|x| x.as_str()).collect();
-    execute_external_command(terminal, aur_helper, &args_ref)?;
+    execute_sandboxable_external_command(terminal, aur_helper, &args_ref)?;
 
     Ok(())
 }

--- a/src/sandbox.rs
+++ b/src/sandbox.rs
@@ -5,11 +5,7 @@ const BWRAP_WARNING: &str =
     "Warning: sandbox=true is set, but bubblewrap (bwrap) is not available on PATH.";
 
 pub fn startup_warning(sandbox_enabled: bool) -> Option<&'static str> {
-    if sandbox_enabled && !bwrap_available() {
-        Some(BWRAP_WARNING)
-    } else {
-        None
-    }
+    if sandbox_enabled && !bwrap_available() { Some(BWRAP_WARNING) } else { None }
 }
 
 pub fn command_for(cmd: &str, args: &[&str], sandbox_enabled: bool) -> (String, Vec<String>) {
@@ -87,11 +83,7 @@ mod tests {
         let separator = args.iter().position(|arg| arg == "--").unwrap();
         assert_eq!(
             &args[separator + 1..],
-            vec![
-                "apt".to_string(),
-                "install".to_string(),
-                "ripgrep".to_string()
-            ]
+            vec!["apt".to_string(), "install".to_string(), "ripgrep".to_string()]
         );
     }
 }

--- a/src/sandbox.rs
+++ b/src/sandbox.rs
@@ -1,0 +1,97 @@
+#[cfg(target_os = "linux")]
+use std::process::Command;
+
+const BWRAP_WARNING: &str =
+    "Warning: sandbox=true is set, but bubblewrap (bwrap) is not available on PATH.";
+
+pub fn startup_warning(sandbox_enabled: bool) -> Option<&'static str> {
+    if sandbox_enabled && !bwrap_available() {
+        Some(BWRAP_WARNING)
+    } else {
+        None
+    }
+}
+
+pub fn command_for(cmd: &str, args: &[&str], sandbox_enabled: bool) -> (String, Vec<String>) {
+    if sandbox_enabled && bwrap_available() {
+        ("bwrap".to_string(), bubblewrap_args(cmd, args))
+    } else {
+        (cmd.to_string(), args.iter().map(|arg| (*arg).to_string()).collect())
+    }
+}
+
+#[cfg(target_os = "linux")]
+pub fn bwrap_available() -> bool {
+    Command::new("bwrap")
+        .arg("--version")
+        .output()
+        .map(|output| output.status.success())
+        .unwrap_or(false)
+}
+
+#[cfg(not(target_os = "linux"))]
+pub fn bwrap_available() -> bool {
+    false
+}
+
+fn bubblewrap_args(cmd: &str, args: &[&str]) -> Vec<String> {
+    let mut wrapped = vec![
+        "--ro-bind".to_string(),
+        "/usr".to_string(),
+        "/usr".to_string(),
+        "--ro-bind".to_string(),
+        "/etc".to_string(),
+        "/etc".to_string(),
+        "--bind".to_string(),
+        "/tmp".to_string(),
+        "/tmp".to_string(),
+        "--proc".to_string(),
+        "/proc".to_string(),
+        "--dev".to_string(),
+        "/dev".to_string(),
+        "--".to_string(),
+        cmd.to_string(),
+    ];
+    wrapped.extend(args.iter().map(|arg| (*arg).to_string()));
+    wrapped
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn leaves_command_unchanged_when_sandbox_disabled() {
+        let (cmd, args) = command_for("sudo", &["apt", "install", "ripgrep"], false);
+
+        assert_eq!(cmd, "sudo");
+        assert_eq!(args, vec!["apt", "install", "ripgrep"]);
+    }
+
+    #[test]
+    fn warns_when_enabled_without_bwrap() {
+        if !bwrap_available() {
+            assert_eq!(startup_warning(true), Some(BWRAP_WARNING));
+        }
+    }
+
+    #[test]
+    fn builds_bubblewrap_args_with_original_command_after_separator() {
+        let args = bubblewrap_args("apt", &["install", "ripgrep"]);
+
+        assert!(args.starts_with(&[
+            "--ro-bind".to_string(),
+            "/usr".to_string(),
+            "/usr".to_string(),
+        ]));
+        let separator = args.iter().position(|arg| arg == "--").unwrap();
+        assert_eq!(
+            &args[separator + 1..],
+            vec![
+                "apt".to_string(),
+                "install".to_string(),
+                "ripgrep".to_string()
+            ]
+        );
+    }
+}


### PR DESCRIPTION
## Summary
- add an opt-in `settings.sandbox` config flag with default `false`
- warn on startup when sandboxing is enabled but `bwrap` is unavailable
- wrap install/remove package manager commands through Bubblewrap on Linux when enabled
- add unit coverage for command preservation, warnings, and bwrap argument construction

## Validation
- `git diff --check`
- Rust toolchain is not installed in this local environment (`cargo`, `rustc`, and `rustfmt` are unavailable), so I will rely on the repository GitHub Actions for compile/test validation.

Closes #88
