### PR TITLE
fix(ui): add contextual keyboard status hint

### DIFF
--- a/src/ui/draw.rs
+++ b/src/ui/draw.rs
@@ -386,6 +386,33 @@ fn draw_settings_tab(frame: &mut Frame, app: &App, area: Rect, theme: &crate::co
     frame.render_widget(paragraph, area);
 }
 
+fn keyboard_hint(app: &App) -> String {
+    let keys = &app.config.keys;
+
+    match app.input_mode {
+        InputMode::Editing => match app.current_tab {
+            crate::ui::app::Tab::Search => {
+                format!("Esc to exit search mode  •  Enter to search  •  {} to quit", keys.quit)
+            }
+            crate::ui::app::Tab::Settings => {
+                format!("Esc to stop editing  •  Enter to save  •  {} to quit", keys.quit)
+            }
+            _ => format!("Esc to stop editing  •  Enter to submit  •  {} to quit", keys.quit),
+        },
+        InputMode::Normal => match app.current_tab {
+            crate::ui::app::Tab::Search => format!(
+                "Press '{}' for help  •  '{}' to search  •  '{}' to quit",
+                keys.help, keys.search_edit, keys.quit
+            ),
+            crate::ui::app::Tab::Settings => format!(
+                "Press '{}' for help  •  Enter/Space to edit  •  '{}' to quit",
+                keys.help, keys.quit
+            ),
+            _ => format!("Press '{}' for help  •  '{}' to quit", keys.help, keys.quit),
+        },
+    }
+}
+
 fn draw_status_bar(frame: &mut Frame, app: &App, area: Rect, theme: &crate::config::Theme) {
     let highlight_color = app.config.get_color(&theme.highlight_color);
     let secondary_color = app.config.get_color(&theme.text_secondary);
@@ -419,8 +446,8 @@ fn draw_status_bar(frame: &mut Frame, app: &App, area: Rect, theme: &crate::conf
         ),
         Span::raw(" | "),
         Span::styled(
-            "Press '?' for help ",
-            Style::default().fg(primary_color).add_modifier(Modifier::ITALIC),
+            keyboard_hint(app),
+            Style::default().fg(primary_color).add_modifier(Modifier::DIM),
         ),
     ]);
 

--- a/src/ui/draw.rs
+++ b/src/ui/draw.rs
@@ -6,7 +6,10 @@ use ratatui::{
     widgets::{Block, BorderType, Clear, List, ListItem, Paragraph, Wrap},
 };
 
-use crate::ui::{app::App, input::InputMode};
+use crate::ui::{
+    app::{App, Tab},
+    input::InputMode,
+};
 
 fn centered_rect(percent_x: u16, percent_y: u16, r: Rect) -> Rect {
     let popup_layout = Layout::vertical([
@@ -387,24 +390,30 @@ fn draw_settings_tab(frame: &mut Frame, app: &App, area: Rect, theme: &crate::co
 }
 
 fn keyboard_hint(app: &App) -> String {
-    let keys = &app.config.keys;
+    keyboard_hint_text(app.input_mode, app.current_tab, &app.config.keys)
+}
 
-    match app.input_mode {
-        InputMode::Editing => match app.current_tab {
-            crate::ui::app::Tab::Search => {
+fn keyboard_hint_text(
+    input_mode: InputMode,
+    current_tab: Tab,
+    keys: &crate::config::Keys,
+) -> String {
+    match input_mode {
+        InputMode::Editing => match current_tab {
+            Tab::Search => {
                 format!("Esc to exit search mode  •  Enter to search  •  {} to quit", keys.quit)
             }
-            crate::ui::app::Tab::Settings => {
+            Tab::Settings => {
                 format!("Esc to stop editing  •  Enter to save  •  {} to quit", keys.quit)
             }
             _ => format!("Esc to stop editing  •  Enter to submit  •  {} to quit", keys.quit),
         },
-        InputMode::Normal => match app.current_tab {
-            crate::ui::app::Tab::Search => format!(
+        InputMode::Normal => match current_tab {
+            Tab::Search => format!(
                 "Press '{}' for help  •  '{}' to search  •  '{}' to quit",
                 keys.help, keys.search_edit, keys.quit
             ),
-            crate::ui::app::Tab::Settings => format!(
+            Tab::Settings => format!(
                 "Press '{}' for help  •  Enter/Space to edit  •  '{}' to quit",
                 keys.help, keys.quit
             ),
@@ -731,4 +740,27 @@ fn draw_help_overlay(frame: &mut Frame, app: &App, theme: &crate::config::Theme)
             .wrap(Wrap { trim: true }),
         area,
     );
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{InputMode, Tab, keyboard_hint_text};
+
+    fn keys() -> crate::config::Keys {
+        crate::config::Config::default().keys
+    }
+
+    #[test]
+    fn normal_search_hint_includes_help_search_and_quit() {
+        let hint = keyboard_hint_text(InputMode::Normal, Tab::Search, &keys());
+
+        assert_eq!(hint, "Press '?' for help  •  'e' to search  •  'q' to quit");
+    }
+
+    #[test]
+    fn editing_settings_hint_is_contextual() {
+        let hint = keyboard_hint_text(InputMode::Editing, Tab::Settings, &keys());
+
+        assert_eq!(hint, "Esc to stop editing  •  Enter to save  •  q to quit");
+    }
 }


### PR DESCRIPTION
## What changed
- Added a contextual keyboard help hint to the permanent bottom status bar in `src/ui/draw.rs`.
- The normal status line now shows the primary app shortcuts for help, search, and quit while preserving the selected-count and package-manager indicators.
- Search mode and settings edit mode show mode-specific guidance so the bottom bar remains useful while the user is typing or editing.

## Why
Issue #53 asks for a persistent keyboard help hint in the status bar. This keeps the most important shortcuts visible without adding a modal, changing the layout structure, or touching package-manager logic.

Fixes https://github.com/pie-314/trx/issues/53

## How it was tested
- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings -A dead_code -A clippy::type_complexity`
- `cargo test --workspace --all-targets --all-features`
- `cargo run -- --help`
- Runtime TUI smoke check with `cargo run`, then quit with `q`
- GitHub CI `Verify` passed
- GitHub CI `Build` passed

## UI evidence
Runtime TUI capture after `cargo run`:

![Runtime status bar evidence](https://gist.githubusercontent.com/saurabhhhcodes/e2593e1d0ae5c1b5ad0ad8723ac43933/raw/trx-pr-104-runtime-status-bar.svg)

The bottom bar now renders:

```text
NORMAL  | Selected: 0  | Manager: Homebrew (macOS/Linux)  | Press '?' for help  •  'e' to search  •  'q' to quit
```

## Scope checklist
- One issue only.
- One file changed: `src/ui/draw.rs`.
- No unrelated formatting or package-manager changes.
- PR targets the required `dev` branch.
