### PR TITLE
feat: add Clear Cache setting to UI

### DIFF
--- a/src/ui/app.rs
+++ b/src/ui/app.rs
@@ -713,18 +713,19 @@ impl App {
                                             if self.current_tab == Tab::Settings =>
                                         {
                                             let mgr_count = self.available_managers.len();
-                                            if self.settings_index == 6 + mgr_count {
+                                            if self.settings_index == 7 + mgr_count {
                                                 self.prev_theme();
-                                            } else if self.settings_index == 6 + mgr_count + 1 {
+                                            } else if self.settings_index == 7 + mgr_count + 1 {
                                                 self.prev_border_style();
-                                            } else if self.settings_index == 6 + mgr_count + 2 {
+                                            } else if self.settings_index == 7 + mgr_count + 2 {
                                                 self.prev_spinner_type();
                                             } else if self.settings_index == 4 {
                                                 self.prev_default_tab();
                                             } else if self.settings_index == 1
                                                 || self.settings_index == 2
-                                                || (self.settings_index >= 6
-                                                    && self.settings_index < 6 + mgr_count)
+                                                || self.settings_index == 6
+                                                || (self.settings_index >= 7
+                                                    && self.settings_index < 7 + mgr_count)
                                             {
                                                 self.handle_settings_toggle();
                                             }
@@ -733,18 +734,19 @@ impl App {
                                             if self.current_tab == Tab::Settings =>
                                         {
                                             let mgr_count = self.available_managers.len();
-                                            if self.settings_index == 6 + mgr_count {
+                                            if self.settings_index == 7 + mgr_count {
                                                 self.next_theme();
-                                            } else if self.settings_index == 6 + mgr_count + 1 {
+                                            } else if self.settings_index == 7 + mgr_count + 1 {
                                                 self.next_border_style();
-                                            } else if self.settings_index == 6 + mgr_count + 2 {
+                                            } else if self.settings_index == 7 + mgr_count + 2 {
                                                 self.next_spinner_type();
                                             } else if self.settings_index == 4 {
                                                 self.next_default_tab();
                                             } else if self.settings_index == 1
                                                 || self.settings_index == 2
-                                                || (self.settings_index >= 6
-                                                    && self.settings_index < 6 + mgr_count)
+                                                || self.settings_index == 6
+                                                || (self.settings_index >= 7
+                                                    && self.settings_index < 7 + mgr_count)
                                             {
                                                 self.handle_settings_toggle();
                                             }
@@ -763,9 +765,9 @@ impl App {
                                         KeyCode::Down | KeyCode::Char('j') => {
                                             if self.current_tab == Tab::Settings {
                                                 let max = if self.config.theme_name == "Custom" {
-                                                    14
+                                                    15
                                                 } else {
-                                                    8
+                                                    9
                                                 };
                                                 if self.settings_index < max {
                                                     self.settings_index += 1;
@@ -838,9 +840,9 @@ impl App {
                 if self.current_tab == Tab::Settings {
                     let mgr_count = self.available_managers.len();
                     let max = if self.config.theme_name == "Custom" {
-                        5 + mgr_count + 6
+                        6 + mgr_count + 6
                     } else {
-                        5 + mgr_count
+                        6 + mgr_count
                     };
                     if self.settings_index < max {
                         self.settings_index += 1;
@@ -900,18 +902,18 @@ impl App {
                     let r = mouse_event.row;
                     let mgr_count = self.available_managers.len() as u16;
 
-                    let idx = if (7..=12).contains(&r) {
+                    let idx = if (7..=13).contains(&r) {
                         Some(r - 7)
-                    } else if r >= 14 && r < 14 + mgr_count {
-                        Some(r - 14 + 6)
-                    } else if r == 15 + mgr_count {
-                        Some(6 + mgr_count)
+                    } else if r >= 15 && r < 15 + mgr_count {
+                        Some(r - 15 + 7)
                     } else if r == 16 + mgr_count {
                         Some(7 + mgr_count)
                     } else if r == 17 + mgr_count {
                         Some(8 + mgr_count)
-                    } else if r >= 19 + mgr_count && r < 25 + mgr_count {
-                        Some(r - (19 + mgr_count) + 7 + mgr_count)
+                    } else if r == 18 + mgr_count {
+                        Some(9 + mgr_count)
+                    } else if r >= 20 + mgr_count && r < 26 + mgr_count {
+                        Some(r - (20 + mgr_count) + 8 + mgr_count)
                     } else {
                         None
                     };
@@ -1004,17 +1006,23 @@ impl App {
                     Color::Cyan,
                 );
             }
-            i if i >= 6 && i < 6 + mgr_count => {
-                let mgr_name = self.available_managers[i - 6].clone();
+            6 => {
+                // Clear Cache
+                crate::managers::SEARCH_CACHE.lock().unwrap().clear();
+                crate::managers::DETAILS_CACHE.lock().unwrap().clear();
+                self.set_popup("Cache cleared successfully".to_string(), Color::Green);
+            }
+            i if i >= 7 && i < 7 + mgr_count => {
+                let mgr_name = self.available_managers[i - 7].clone();
                 self.toggle_manager(&mgr_name);
             }
-            i if i == 6 + mgr_count => {
+            i if i == 7 + mgr_count => {
                 self.next_theme();
             }
-            i if i == 6 + mgr_count + 1 => {
+            i if i == 7 + mgr_count + 1 => {
                 self.next_border_style();
             }
-            i if i == 6 + mgr_count + 2 => {
+            i if i == 7 + mgr_count + 2 => {
                 self.next_spinner_type();
             }
             _ => {
@@ -1024,12 +1032,12 @@ impl App {
                     3 => self.config.settings.search_debounce_ms.to_string(),
                     4 => self.config.settings.default_tab.clone(),
                     5 => self.config.settings.max_search_results.to_string(),
-                    i if i >= 7 + mgr_count
-                        && i <= 12 + mgr_count
+                    i if i >= 8 + mgr_count
+                        && i <= 13 + mgr_count
                         && self.config.theme_name == "Custom" =>
                     {
                         let theme = self.config.custom_theme.as_ref().unwrap();
-                        match i - (7 + mgr_count) {
+                        match i - (8 + mgr_count) {
                             0 => theme.border_color.clone(),
                             1 => theme.highlight_color.clone(),
                             2 => theme.success_color.clone(),
@@ -1042,8 +1050,8 @@ impl App {
                     _ => String::new(),
                 };
                 if !self.input.is_empty()
-                    || (self.settings_index >= 7 + mgr_count
-                        && self.settings_index <= 12 + mgr_count)
+                    || (self.settings_index >= 8 + mgr_count
+                        && self.settings_index <= 13 + mgr_count)
                 {
                     self.input_mode = InputMode::Editing;
                     self.character_index = self.input.chars().count();
@@ -1078,9 +1086,9 @@ impl App {
                     saved = true;
                 }
             }
-            i if i >= 7 + mgr_count && i <= 12 + mgr_count => {
+            i if i >= 8 + mgr_count && i <= 13 + mgr_count => {
                 if let Some(ref mut theme) = self.config.custom_theme {
-                    match i - (7 + mgr_count) {
+                    match i - (8 + mgr_count) {
                         0 => {
                             theme.border_color = val;
                         }

--- a/src/ui/draw.rs
+++ b/src/ui/draw.rs
@@ -327,9 +327,10 @@ fn draw_settings_tab(frame: &mut Frame, app: &App, area: Rect, theme: &crate::co
     );
     draw_setting!(4, "Default Tab", &app.config.settings.default_tab, false);
     draw_setting!(5, "Max Results", &app.config.settings.max_search_results.to_string(), false);
+    draw_setting!(6, "Clear Cache", "Press Enter/Space", false);
     settings_lines.push(Line::from(""));
 
-    let mut current_idx = 6;
+    let mut current_idx = 7;
 
     // Managers
     settings_lines.push(Line::from(Span::styled(


### PR DESCRIPTION
## Description
This PR implements the **Clear Cache** setting in the Settings tab. TRX caches search results and package details in memory to reduce redundant queries, and this PR adds a straightforward way for users to manually flush this cache from the UI to force fresh data from their backend package managers.

## Changes Made
* **UI Integration (`src/ui/draw.rs`)**: Appended the new "Clear Cache" row to the end of the `--- General ---` section in the Settings tab. It correctly displays the action instructions (`Press Enter/Space`) and works with the existing row-highlighting aesthetics.
* **Index State Shifting (`src/ui/app.rs`)**: Carefully updated the internal index mapping logic across the application. Keyboard boundary logic (like max settings limits), mouse click targets, and toggle handlers were cleanly shifted by 1 for all subsequent settings (Managers, Aesthetics, Custom Colors) to prevent regressions.
* **Action Handler (`src/ui/app.rs`)**: Handled the action inside `handle_settings_toggle()`. When activated, it safely locks the `SEARCH_CACHE` and `DETAILS_CACHE` global `lazy_static` mutexes inside `crate::managers` and executes `.clear()` on them.
* **Visual Feedback**: Hooks into the existing `popup_message` system to trigger a brief, green `"Cache cleared successfully"` popup upon execution so the user knows the cache was successfully flushed.

## Verification
- Built and ran the project using `cargo build --release`.
- Navigated to the Settings tab and verified the new option renders correctly.
- Confirmed `Up`/`Down` and `j`/`k` keyboard navigation, as well as mouse scrolling and clicking, continue to work across all options in the Settings tab without regressions.
- Triggered the action on the Clear Cache row and verified the green confirmation popup appears (see attached screenshot).
- Verified that searching for a package after clearing results in fetching fresh data with the loading spinner.
<img width="1920" height="1014" alt="image" src="https://github.com/user-attachments/assets/4df75469-0fd6-473c-97fc-3a3babbc19a0" />