### PR TITLE
feat(ui): add visual flair to tab bar with configurable icons

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -13,10 +13,16 @@ pub struct Settings {
     pub enabled_managers: Vec<String>,
     pub border_style: String, // "Plain", "Rounded", "Double", "Thick"
     pub spinner_type: String, // "Dots", "Bars", "Pulse", "Classic", "Arc", "Braille"
+    #[serde(default = "default_tab_icon_style")]
+    pub tab_icon_style: String, // "Unicode", "NerdFont", "None"
     /// Version the user explicitly skipped. Ignored while the same tag is
     /// latest; cleared from config when a genuinely newer release is detected,
     /// so the prompt resurfaces automatically for new updates.
     pub skipped_update_version: Option<String>,
+}
+
+fn default_tab_icon_style() -> String {
+    "Unicode".to_string()
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
@@ -78,6 +84,7 @@ impl Default for Config {
                 ],
                 border_style: "Rounded".to_string(),
                 spinner_type: "Dots".to_string(),
+                tab_icon_style: "Unicode".to_string(),
                 skipped_update_version: None,
             },
             keys: Keys {

--- a/src/ui/app.rs
+++ b/src/ui/app.rs
@@ -499,6 +499,26 @@ impl App {
         self.set_popup(format!("Spinner: {}", self.config.settings.spinner_type), Color::Cyan);
     }
 
+    fn next_tab_icon_style(&mut self) {
+        let styles = ["Unicode", "NerdFont", "None"];
+        let current_pos =
+            styles.iter().position(|&s| s == self.config.settings.tab_icon_style).unwrap_or(0);
+        let next_pos = (current_pos + 1) % styles.len();
+        self.config.settings.tab_icon_style = styles[next_pos].to_string();
+        let _ = self.config.save();
+        self.set_popup(format!("Tab Icons: {}", self.config.settings.tab_icon_style), Color::Cyan);
+    }
+
+    fn prev_tab_icon_style(&mut self) {
+        let styles = ["Unicode", "NerdFont", "None"];
+        let current_pos =
+            styles.iter().position(|&s| s == self.config.settings.tab_icon_style).unwrap_or(0);
+        let next_pos = if current_pos == 0 { styles.len() - 1 } else { current_pos - 1 };
+        self.config.settings.tab_icon_style = styles[next_pos].to_string();
+        let _ = self.config.save();
+        self.set_popup(format!("Tab Icons: {}", self.config.settings.tab_icon_style), Color::Cyan);
+    }
+
     pub fn run(mut self, terminal: &mut DefaultTerminal) -> Result<Option<String>> {
         loop {
             if let Tab::Search = self.current_tab {
@@ -719,6 +739,8 @@ impl App {
                                                 self.prev_border_style();
                                             } else if self.settings_index == 6 + mgr_count + 2 {
                                                 self.prev_spinner_type();
+                                            } else if self.settings_index == 6 + mgr_count + 3 {
+                                                self.prev_tab_icon_style();
                                             } else if self.settings_index == 4 {
                                                 self.prev_default_tab();
                                             } else if self.settings_index == 1
@@ -739,6 +761,8 @@ impl App {
                                                 self.next_border_style();
                                             } else if self.settings_index == 6 + mgr_count + 2 {
                                                 self.next_spinner_type();
+                                            } else if self.settings_index == 6 + mgr_count + 3 {
+                                                self.next_tab_icon_style();
                                             } else if self.settings_index == 4 {
                                                 self.next_default_tab();
                                             } else if self.settings_index == 1
@@ -762,10 +786,11 @@ impl App {
                                         }
                                         KeyCode::Down | KeyCode::Char('j') => {
                                             if self.current_tab == Tab::Settings {
+                                                let mgr_count = self.available_managers.len();
                                                 let max = if self.config.theme_name == "Custom" {
-                                                    14
+                                                    6 + mgr_count + 9
                                                 } else {
-                                                    8
+                                                    6 + mgr_count + 3
                                                 };
                                                 if self.settings_index < max {
                                                     self.settings_index += 1;
@@ -838,9 +863,9 @@ impl App {
                 if self.current_tab == Tab::Settings {
                     let mgr_count = self.available_managers.len();
                     let max = if self.config.theme_name == "Custom" {
-                        5 + mgr_count + 6
+                        6 + mgr_count + 9
                     } else {
-                        5 + mgr_count
+                        6 + mgr_count + 3
                     };
                     if self.settings_index < max {
                         self.settings_index += 1;
@@ -874,10 +899,14 @@ impl App {
                 // Tab switching
                 if mouse_event.row >= 1 && mouse_event.row <= 3 {
                     let col = mouse_event.column.saturating_sub(1);
-                    let tab_titles = ["Search", "Installed", "Updates", "Settings"];
+                    let tab_titles = match self.config.settings.tab_icon_style.as_str() {
+                        "NerdFont" => vec!["  Search", "  Installed", "󰑐  Updates", "  Settings"],
+                        "None" => vec!["Search", "Installed", "Updates", "Settings"],
+                        _ => vec!["🔍 Search", "📦 Installed", "🔄 Updates", "⚙️ Settings"],
+                    };
                     let mut current_x = 0;
                     for (i, title) in tab_titles.iter().enumerate() {
-                        let width = title.len() as u16;
+                        let width = ratatui::text::Span::raw(*title).width() as u16;
                         if col >= current_x && col < current_x + width {
                             let new_tab = match i {
                                 0 => Tab::Search,
@@ -910,8 +939,10 @@ impl App {
                         Some(7 + mgr_count)
                     } else if r == 17 + mgr_count {
                         Some(8 + mgr_count)
-                    } else if r >= 19 + mgr_count && r < 25 + mgr_count {
-                        Some(r - (19 + mgr_count) + 7 + mgr_count)
+                    } else if r == 18 + mgr_count {
+                        Some(9 + mgr_count)
+                    } else if r >= 20 + mgr_count && r < 26 + mgr_count {
+                        Some(r - (20 + mgr_count) + 10 + mgr_count)
                     } else {
                         None
                     };
@@ -1017,6 +1048,9 @@ impl App {
             i if i == 6 + mgr_count + 2 => {
                 self.next_spinner_type();
             }
+            i if i == 6 + mgr_count + 3 => {
+                self.next_tab_icon_style();
+            }
             _ => {
                 // If it's a string/color field, enter editing mode
                 self.input = match self.settings_index {
@@ -1024,12 +1058,12 @@ impl App {
                     3 => self.config.settings.search_debounce_ms.to_string(),
                     4 => self.config.settings.default_tab.clone(),
                     5 => self.config.settings.max_search_results.to_string(),
-                    i if i >= 7 + mgr_count
-                        && i <= 12 + mgr_count
+                    i if i >= 8 + mgr_count
+                        && i <= 13 + mgr_count
                         && self.config.theme_name == "Custom" =>
                     {
                         let theme = self.config.custom_theme.as_ref().unwrap();
-                        match i - (7 + mgr_count) {
+                        match i - (8 + mgr_count) {
                             0 => theme.border_color.clone(),
                             1 => theme.highlight_color.clone(),
                             2 => theme.success_color.clone(),
@@ -1042,8 +1076,8 @@ impl App {
                     _ => String::new(),
                 };
                 if !self.input.is_empty()
-                    || (self.settings_index >= 7 + mgr_count
-                        && self.settings_index <= 12 + mgr_count)
+                    || (self.settings_index >= 8 + mgr_count
+                        && self.settings_index <= 13 + mgr_count)
                 {
                     self.input_mode = InputMode::Editing;
                     self.character_index = self.input.chars().count();
@@ -1078,9 +1112,9 @@ impl App {
                     saved = true;
                 }
             }
-            i if i >= 7 + mgr_count && i <= 12 + mgr_count => {
+            i if i >= 8 + mgr_count && i <= 13 + mgr_count => {
                 if let Some(ref mut theme) = self.config.custom_theme {
-                    match i - (7 + mgr_count) {
+                    match i - (8 + mgr_count) {
                         0 => {
                             theme.border_color = val;
                         }

--- a/src/ui/app.rs
+++ b/src/ui/app.rs
@@ -900,7 +900,9 @@ impl App {
                 if mouse_event.row >= 1 && mouse_event.row <= 3 {
                     let col = mouse_event.column.saturating_sub(1);
                     let tab_titles = match self.config.settings.tab_icon_style.as_str() {
-                        "NerdFont" => vec!["  Search", "  Installed", "󰑐  Updates", "  Settings"],
+                        "NerdFont" => {
+                            vec!["  Search", "  Installed", "󰑐  Updates", "  Settings"]
+                        }
                         "None" => vec!["Search", "Installed", "Updates", "Settings"],
                         _ => vec!["🔍 Search", "📦 Installed", "🔄 Updates", "⚙️ Settings"],
                     };

--- a/src/ui/draw.rs
+++ b/src/ui/draw.rs
@@ -202,7 +202,11 @@ fn draw_tabs(frame: &mut Frame, app: &App, area: Rect, theme: &crate::config::Th
     let highlight_color = app.config.get_color(&theme.highlight_color);
     let border_type = get_border_type(&app.config.settings.border_style);
 
-    let tab_titles = vec!["Search", "Installed", "Updates", "Settings"];
+    let tab_titles = match app.config.settings.tab_icon_style.as_str() {
+        "NerdFont" => vec!["  Search", "  Installed", "󰑐  Updates", "  Settings"],
+        "None" => vec!["Search", "Installed", "Updates", "Settings"],
+        _ => vec!["🔍 Search", "📦 Installed", "🔄 Updates", "⚙️ Settings"],
+    };
     let tabs = ratatui::widgets::Tabs::new(tab_titles)
         .block(
             Block::bordered()
@@ -356,7 +360,8 @@ fn draw_settings_tab(frame: &mut Frame, app: &App, area: Rect, theme: &crate::co
     draw_setting!(current_idx, "Theme Preset", &app.config.theme_name, false);
     draw_setting!(current_idx + 1, "Border Style", &app.config.settings.border_style, false);
     draw_setting!(current_idx + 2, "Spinner Type", &app.config.settings.spinner_type, false);
-    current_idx += 3;
+    draw_setting!(current_idx + 3, "Tab Icon Style", &app.config.settings.tab_icon_style, false);
+    current_idx += 4;
 
     if app.config.theme_name == "Custom" {
         settings_lines.push(Line::from(""));


### PR DESCRIPTION
## Description
<!-- Provide a brief summary of the changes and the motivation behind them. -->
Adds visual flair to the application's tab bar by introducing icons before the tab labels (Search, Installed, Updates, Settings). This pull request implements configurable icons with support for standard Unicode symbols and Nerd Font variants, improving the overall aesthetics without forcing any external font dependencies. Also includes a fix for a mouse-click boundary alignment issue caused by the new icon widths.

Fixes # (issue)

## Type of Change
<!-- Please delete options that are not relevant. -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?
<!-- Please describe the tests that you ran to verify your changes. -->
- [x] Manual test (Ran `cargo run` and visually verified that tab icons correctly render standard Unicode emojis by default. Toggled the "Tab Icon Style" setting in the Aesthetics menu and verified that mouse clicks align perfectly with the updated visual widths of the tabs.)
- [x] `cargo test`

## Checklist:
- [x] My code follows the [Coding Guidelines](CONTRIBUTING.md#4-coding-guidelines).
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have NOT added useless AI-generated comments.
- [x] I have NOT deleted existing unrelated comments.
- [x] I have NOT modified files unrelated to this task.
- [ ] I have included screenshots/recordings (for UI changes).
- [x] My changes generate no new warnings (clippy/fmt).
- [ ] I have linked the issue I am working on.

## Screenshots (if applicable)
<img width="1568" height="799" alt="image" src="https://github.com/user-attachments/assets/ee38778c-79d8-4fae-bb40-ce337e0e9951" />

#Screen recording:

https://github.com/user-attachments/assets/633e3d35-efd1-4578-8f5f-320f95ef5fbe


