### PR TITLE
feat(ui): add interactive keybinding editor to settings menu

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -108,6 +108,27 @@ impl Default for Config {
     }
 }
 
+impl Keys {
+    /// Mutates a keybinding string field inside the struct dynamically based on its text action name.
+    pub fn update_action_key(&mut self, action_name: &str, new_key_str: String) {
+        match action_name {
+            "quit" => self.quit = new_key_str,
+            "install" => self.install = new_key_str,
+            "remove" => self.remove = new_key_str,
+            "update" => self.update = new_key_str,
+            "search_edit" => self.search_edit = new_key_str,
+            "toggle_select" => self.toggle_select = new_key_str,
+            "tab_next" => self.tab_next = new_key_str,
+            "tab_prev" => self.tab_prev = new_key_str,
+            "system_upgrade" => self.system_upgrade = new_key_str,
+            "refresh_db" => self.refresh_db = new_key_str,
+            "help" => self.help = new_key_str,
+            "check_update" => self.check_update = new_key_str,
+            _ => {}
+        }
+    }
+}
+
 impl Config {
     pub fn load() -> Self {
         if let Some(proj_dirs) = ProjectDirs::from("", "", "trx") {

--- a/src/main.rs
+++ b/src/main.rs
@@ -70,7 +70,7 @@ fn main() -> Result<()> {
     restore();
 
     match app_result {
-        Ok(Some(url)) => {
+        Ok(Some(ref url)) => {
             println!("Downloading update...");
             match updater::update_self(&url) {
                 Ok(_) => {

--- a/src/ui/app.rs
+++ b/src/ui/app.rs
@@ -53,6 +53,7 @@ pub struct App {
     pub spinner_tick: u8,
     pub manager: Arc<Box<dyn managers::PackageManager>>,
     pub config: crate::config::Config,
+    pub selected_key_action: Option<String>,
     pub settings_index: usize,
     pub details_scroll: u16,
     pub available_managers: Vec<String>,
@@ -123,6 +124,7 @@ impl App {
             spinner_tick: 0,
             manager,
             config,
+            selected_key_action: None,
             settings_index: 0,
             details_scroll: 0,
             character_index: 0,
@@ -616,6 +618,39 @@ impl App {
                         }
 
                         match self.input_mode {
+                            InputMode::Rebinding if key.kind == KeyEventKind::Press => {
+                                match key.code {
+                                    KeyCode::Esc => {
+                                        self.selected_key_action = None;
+                                        self.input_mode = InputMode::Normal;
+                                    }
+                                    KeyCode::Char(c) => {
+                                        if let Some(ref action) = self.selected_key_action{
+                                            let new_key_str = c.to_string();
+                                            match action.as_str() {
+                                                "quit" => self.config.keys.quit = new_key_str,
+                                                "install" => self.config.keys.install = new_key_str,
+                                                "remove" => self.config.keys.remove = new_key_str,
+                                                "update" => self.config.keys.update = new_key_str,
+                                                "search_edit" => self.config.keys.search_edit = new_key_str,
+                                                "toggle_select" => self.config.keys.toggle_select = new_key_str,
+                                                "tab_next" => self.config.keys.tab_next = new_key_str,
+                                                "tab_prev" => self.config.keys.tab_prev = new_key_str,
+                                                "system_upgrade" => self.config.keys.system_upgrade = new_key_str,
+                                                "refresh_db" => self.config.keys.refresh_db = new_key_str,
+                                                "help" => self.config.keys.help = new_key_str,
+                                                "check_update" => self.config.keys.check_update = new_key_str,
+                                                _ => {}
+                                            }
+                                            let _ = self.config.save();
+                                            self.set_popup(format!("Bound [{}] to '{}'", action, c), Color::Green);
+                                        }
+                                        self.selected_key_action = None;
+                                        self.input_mode = InputMode::Normal;
+                                    }
+                                    _ => {} 
+                                }
+                            }
                             InputMode::Normal if key.kind == KeyEventKind::Press => {
                                 let keys = &self.config.keys;
 
@@ -763,9 +798,9 @@ impl App {
                                         KeyCode::Down | KeyCode::Char('j') => {
                                             if self.current_tab == Tab::Settings {
                                                 let max = if self.config.theme_name == "Custom" {
-                                                    14
+                                                    14+11
                                                 } else {
-                                                    8
+                                                    8+11
                                                 };
                                                 if self.settings_index < max {
                                                     self.settings_index += 1;
@@ -815,6 +850,32 @@ impl App {
                                 }
                                 _ => {}
                             },
+                            InputMode::Rebinding if key.kind == KeyEventKind::Press => {
+                                if key.code == KeyCode::Esc{
+                                    self.input_mode = InputMode::Normal;
+                                    self.selected_key_action = None;
+                                    continue;
+                                }
+                                let incoming_key_string = match key.code{
+                                    KeyCode::Char(c) => c.to_string(),
+                                    KeyCode::Tab => "Tab".to_string(),
+                                    KeyCode::BackTab => "BackTab".to_string(),
+                                    KeyCode::Enter => "Enter".to_string(),
+                                    KeyCode::F(num) => format!("F{}",num),
+                                    _ => continue, 
+                                };
+                                if let Some(ref action_to_rebind) = self.selected_key_action{
+                                    self.config.keys.update_action_key(action_to_rebind,incoming_key_string);
+                                    if let Err(e) = self.config.save(){
+                                        self.set_popup(format!("Save Failed: {}",e),Color::Red);
+                                    } 
+                                    else{
+                                        self.set_popup("Keybinding updated successfully!".to_string(),Color::Green);
+                                    }
+                                }
+                                self.selected_key_action =None;
+                                self.input_mode = InputMode::Normal;
+                            }
 
                             _ => {}
                         }
@@ -838,9 +899,9 @@ impl App {
                 if self.current_tab == Tab::Settings {
                     let mgr_count = self.available_managers.len();
                     let max = if self.config.theme_name == "Custom" {
-                        5 + mgr_count + 6
+                        5 + mgr_count + 6+11
                     } else {
-                        5 + mgr_count
+                        5 + mgr_count+11
                     };
                     if self.settings_index < max {
                         self.settings_index += 1;
@@ -985,6 +1046,11 @@ impl App {
 
     fn handle_settings_toggle(&mut self) {
         let mgr_count = self.available_managers.len();
+        if let Some(action_name) = self.get_selected_keybinding_action_name() {
+            self.selected_key_action = Some(action_name);
+            self.input_mode = InputMode::Rebinding;
+            return;
+        }
         match self.settings_index {
             1 => {
                 // Auto Update Check
@@ -1053,6 +1119,9 @@ impl App {
     }
 
     fn handle_settings_save(&mut self) {
+        if self.get_selected_keybinding_action_name().is_some() {
+            return;
+        }
         let val = self.input.trim().to_string();
         let mgr_count = self.available_managers.len();
         let mut saved = false;
@@ -1107,11 +1176,36 @@ impl App {
             _ => {}
         }
 
-        if saved {
+        if saved{
             let _ = self.config.save();
             self.set_popup("Settings saved".to_string(), Color::Green);
-        } else {
+        } 
+        else{
             self.set_popup("Invalid input".to_string(), Color::Red);
+        }
+    }
+    pub fn get_selected_keybinding_action_name(&self) -> Option<String> {
+        let mgr_count = self.available_managers.len();
+        let baseline_start = 6 + mgr_count + 3; 
+        if self.settings_index >= baseline_start && self.settings_index < baseline_start + 12 {
+            match self.settings_index - baseline_start{
+                0 => Some("quit".to_string()),
+                1 => Some("install".to_string()),
+                2 => Some("remove".to_string()),
+                3 => Some("update".to_string()),
+                4 => Some("search_edit".to_string()),
+                5 => Some("toggle_select".to_string()),
+                6 => Some("tab_next".to_string()),
+                7 => Some("tab_prev".to_string()),
+                8 => Some("system_upgrade".to_string()),
+                9 => Some("refresh_db".to_string()),
+                10 => Some("help".to_string()),
+                11 => Some("check_update".to_string()),
+                _ => None,
+            }
+        } 
+        else{
+            None
         }
     }
 }

--- a/src/ui/app.rs
+++ b/src/ui/app.rs
@@ -57,6 +57,7 @@ pub struct App {
     pub settings_index: usize,
     pub details_scroll: u16,
     pub available_managers: Vec<String>,
+    pub in_keybindings_menu: bool,
     pub popup_message: Option<(String, Color)>, // (message, color)
     result_tx: Sender<(String, Vec<Package>)>,
     result_rx: Receiver<(String, Vec<Package>)>,
@@ -119,6 +120,7 @@ impl App {
             details_state: DetailsState::Empty,
             last_selected: usize::MAX,
             show_help: false,
+            in_keybindings_menu: false,
             update_prompt: None,
             update_selected_yes: true,
             spinner_tick: 0,
@@ -798,9 +800,9 @@ impl App {
                                         KeyCode::Down | KeyCode::Char('j') => {
                                             if self.current_tab == Tab::Settings {
                                                 let max = if self.config.theme_name == "Custom" {
-                                                    14+11
+                                                    14+12
                                                 } else {
-                                                    8+11
+                                                    8+12
                                                 };
                                                 if self.settings_index < max {
                                                     self.settings_index += 1;
@@ -1186,7 +1188,10 @@ impl App {
     }
     pub fn get_selected_keybinding_action_name(&self) -> Option<String> {
         let mgr_count = self.available_managers.len();
-        let baseline_start = 6 + mgr_count + 3; 
+        let mut baseline_start = 6 + mgr_count + 3; 
+        if self.config.theme_name == "Custom"{
+            baseline_start += 6;
+        }
         if self.settings_index >= baseline_start && self.settings_index < baseline_start + 12 {
             match self.settings_index - baseline_start{
                 0 => Some("quit".to_string()),

--- a/src/ui/draw.rs
+++ b/src/ui/draw.rs
@@ -110,6 +110,22 @@ pub fn draw_ui(frame: &mut Frame, app: &mut App) {
     if let Some((msg, color)) = &app.popup_message {
         draw_popup(frame, msg, *color, &theme_colors, &app.config.settings.border_style);
     }
+    if matches!(app.input_mode,crate::ui::input::InputMode::Rebinding){
+        let popup_area = centered_rect(60,20,frame.area());
+        let block = ratatui::widgets::Block::default()
+            .title(" Rebind System Keybinding ")
+            .borders(ratatui::widgets::Borders::ALL)
+            .border_style(ratatui::style::Style::default().fg(ratatui::style::Color::Yellow));
+        let binding_text = format!(
+            "\nModifying shortcut action: [{}]\n\nPress any keyboard key to assign...\n(Press ESC to return safely)",
+            app.selected_key_action.as_deref().unwrap_or("Unknown")
+        );  
+        let overlay_widget = ratatui::widgets::Paragraph::new(binding_text)
+            .alignment(ratatui::layout::Alignment::Center)
+            .block(block);
+        frame.render_widget(ratatui::widgets::Clear, popup_area); 
+        frame.render_widget(overlay_widget, popup_area);
+    }
 }
 
 fn draw_update_prompt(frame: &mut Frame, app: &App, theme: &crate::config::Theme) {
@@ -190,6 +206,10 @@ fn draw_help_header(frame: &mut Frame, app: &App, area: Rect) {
                 "Enter".bold(),
                 " to submit".into(),
             ],
+            Style::default(),
+        ),
+        InputMode::Rebinding => (
+            vec!["[Esc] Cancel".into()],
             Style::default(),
         ),
     };
@@ -371,9 +391,27 @@ fn draw_settings_tab(frame: &mut Frame, app: &App, area: Rect, theme: &crate::co
             draw_setting!(current_idx + 3, "Error Color", &ct.error_color, false);
             draw_setting!(current_idx + 4, "Text Primary", &ct.text_primary, false);
             draw_setting!(current_idx + 5, "Text Secondary", &ct.text_secondary, false);
+            current_idx += 6;
         }
     }
-
+    settings_lines.push(Line::from(""));
+    settings_lines.push(Line::from(Span::styled(
+        "--- Keybindings ---",
+        Style::default().fg(highlight_color).add_modifier(Modifier::BOLD),
+    )));
+    let keys = &app.config.keys;
+    draw_setting!(current_idx, "Quit Application", &keys.quit, false);
+    draw_setting!(current_idx + 1, "Install Package", &keys.install, false);
+    draw_setting!(current_idx + 2, "Remove Package", &keys.remove, false);
+    draw_setting!(current_idx + 3, "Update Package", &keys.update, false);
+    draw_setting!(current_idx + 4, "Search / Edit", &keys.search_edit, false);
+    draw_setting!(current_idx + 5, "Toggle Select", &keys.toggle_select, false);
+    draw_setting!(current_idx + 6, "Next Tab", &keys.tab_next, false);
+    draw_setting!(current_idx + 7, "Previous Tab", &keys.tab_prev, false);
+    draw_setting!(current_idx + 8, "System Upgrade", &keys.system_upgrade, false);
+    draw_setting!(current_idx + 9, "Refresh Database", &keys.refresh_db, false);
+    draw_setting!(current_idx + 10, "Open Help Menu", &keys.help, false);
+    draw_setting!(current_idx + 11, "Check Updates", &keys.check_update, false);
     let paragraph = Paragraph::new(settings_lines)
         .block(
             Block::bordered()
@@ -394,6 +432,7 @@ fn draw_status_bar(frame: &mut Frame, app: &App, area: Rect, theme: &crate::conf
     let mode_str = match app.input_mode {
         InputMode::Normal => " NORMAL ",
         InputMode::Editing => " EDITING ",
+        InputMode::Rebinding => " REBINDING ",
     };
 
     let mode_style = match app.input_mode {
@@ -402,6 +441,9 @@ fn draw_status_bar(frame: &mut Frame, app: &App, area: Rect, theme: &crate::conf
         }
         InputMode::Editing => {
             Style::default().bg(Color::Yellow).fg(Color::Black).add_modifier(Modifier::BOLD)
+        }
+        InputMode::Rebinding => {
+            Style::default().bg(Color::Magenta).fg(Color::White).add_modifier(Modifier::BOLD)
         }
     };
 

--- a/src/ui/draw.rs
+++ b/src/ui/draw.rs
@@ -405,13 +405,16 @@ fn draw_settings_tab(frame: &mut Frame, app: &App, area: Rect, theme: &crate::co
     draw_setting!(current_idx + 2, "Remove Package", &keys.remove, false);
     draw_setting!(current_idx + 3, "Update Package", &keys.update, false);
     draw_setting!(current_idx + 4, "Search / Edit", &keys.search_edit, false);
-    draw_setting!(current_idx + 5, "Toggle Select", &keys.toggle_select, false);
+    draw_setting!(current_idx + 5, "Toggle Select", &keys.toggle_select, false); 
     draw_setting!(current_idx + 6, "Next Tab", &keys.tab_next, false);
     draw_setting!(current_idx + 7, "Previous Tab", &keys.tab_prev, false);
     draw_setting!(current_idx + 8, "System Upgrade", &keys.system_upgrade, false);
     draw_setting!(current_idx + 9, "Refresh Database", &keys.refresh_db, false);
     draw_setting!(current_idx + 10, "Open Help Menu", &keys.help, false);
     draw_setting!(current_idx + 11, "Check Updates", &keys.check_update, false);
+    let visible_height = area.height.saturating_sub(2) as usize; // subtract borders
+    let scroll_offset = app.settings_index.saturating_sub(visible_height / 2) as u16;
+
     let paragraph = Paragraph::new(settings_lines)
         .block(
             Block::bordered()
@@ -419,9 +422,36 @@ fn draw_settings_tab(frame: &mut Frame, app: &App, area: Rect, theme: &crate::co
                 .border_type(border_type)
                 .border_style(Style::default().fg(border_color)),
         )
-        .wrap(Wrap { trim: false });
+        .wrap(Wrap { trim: false })
+        .scroll((scroll_offset, 0));
 
     frame.render_widget(paragraph, area);
+
+    if matches!(app.input_mode, InputMode::Rebinding){
+        let popup_area = get_popup_area(55, 35, area);
+        frame.render_widget(Clear, popup_area);
+        let action_name = app.get_selected_keybinding_action_name().unwrap_or_else(|| "Unknown".to_string());
+        let popup_text = vec![
+            Line::from(""),
+            Line::from(Span::styled("Press the new key combination to assign...", Style::default().fg(secondary_color))),
+            Line::from(""),
+            Line::from(vec![
+                Span::raw(" Rebinding Action: "),
+                Span::styled(action_name, Style::default().fg(highlight_color).add_modifier(Modifier::BOLD)),
+            ]),
+            Line::from(""),
+            Line::from(Span::styled(" [Press ESC to Cancel]", Style::default().fg(app.config.get_color(&theme.error_color)))),
+        ];
+        let popup_block = Paragraph::new(popup_text)
+            .block(
+                Block::bordered()
+                    .title(" ⚠️ Keybinding Editor ")
+                    .border_style(Style::default().fg(highlight_color))
+                    .border_type(BorderType::Double), 
+            )
+            .wrap(Wrap { trim: true });
+        frame.render_widget(popup_block, popup_area);
+    }
 }
 
 fn draw_status_bar(frame: &mut Frame, app: &App, area: Rect, theme: &crate::config::Theme) {
@@ -746,4 +776,24 @@ fn draw_help_overlay(frame: &mut Frame, app: &App, theme: &crate::config::Theme)
             .wrap(Wrap { trim: true }),
         area,
     );
+}
+
+fn get_popup_area(percent_x: u16, percent_y: u16, r: Rect) -> Rect {
+    let popup_layout = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([
+            Constraint::Percentage((100 - percent_y) / 2),
+            Constraint::Percentage(percent_y),
+            Constraint::Percentage((100 - percent_y) / 2),
+        ])
+        .split(r);
+
+    Layout::default()
+        .direction(Direction::Horizontal)
+        .constraints([
+            Constraint::Percentage((100 - percent_x) / 2),
+            Constraint::Percentage(percent_x),
+            Constraint::Percentage((100 - percent_x) / 2),
+        ])
+        .split(popup_layout[1])[1]
 }

--- a/src/ui/input.rs
+++ b/src/ui/input.rs
@@ -2,4 +2,5 @@
 pub enum InputMode {
     Normal,
     Editing,
+    Rebinding,
 }


### PR DESCRIPTION
## Description
added a interactive keybinding editor sub menu in settings tab which will allow users to rebind all application control hotkeys dynamically from TUI interface & remove the need to manually edit the `config.toml` file

Fixes # (issue #59 )

## Type of Change
<!-- Please delete options that are not relevant. -->
- [x] New feature (non-breaking change which adds functionality)


## How Has This Been Tested?
<!-- Please describe the tests that you ran to verify your changes. -->
- [x] Manual test (please describe): launched TUI with `cargo run` moved to settings tab then verified that both arrow keys and the mouse scroll down through keybinding options. Then I triggered a rebind using `Enter` and also  confirmed the config wrote to config.toml 

- [x] `cargo test`

## Checklist:
- [x] My code follows the [Coding Guidelines](CONTRIBUTING.md#4-coding-guidelines).
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have NOT added useless AI-generated comments.
- [x] I have NOT deleted existing unrelated comments.
- [x] I have NOT modified files unrelated to this task.
- [x] I have included screenshots/recordings (for UI changes).
- [x] My changes generate no new warnings (clippy/fmt).
- [x] I have linked the issue I am working on.

## Screenshots (if applicable)
<!-- Add screenshots or screen recordings here -->

<img width="1912" height="1136" alt="image" src="https://github.com/user-attachments/assets/ea59ed63-0144-480a-ae04-f9fb0121e787" />

