### PR TITLE
feat: add persistent history log and TUI History tab

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -24,6 +24,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
+name = "android_system_properties"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "anyhow"
 version = "1.0.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -34,6 +43,12 @@ name = "atomic-waker"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
+
+[[package]]
+name = "autocfg"
+version = "1.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 
 [[package]]
 name = "backtrace"
@@ -104,6 +119,19 @@ name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
+
+[[package]]
+name = "chrono"
+version = "0.4.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1aa79e62e7697b8e29b513a68abacf485adcd1fe8284a4316c5ae868e6633327"
+dependencies = [
+ "iana-time-zone",
+ "js-sys",
+ "num-traits",
+ "wasm-bindgen",
+ "windows-link",
+]
 
 [[package]]
 name = "color-eyre"
@@ -644,6 +672,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "iana-time-zone"
+version = "0.1.65"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e31bc9ad994ba00e440a8aa5c9ef0ec67d5cb5e5cb0cc7f8b744a35b389cc470"
+dependencies = [
+ "android_system_properties",
+ "core-foundation-sys",
+ "iana-time-zone-haiku",
+ "js-sys",
+ "log",
+ "wasm-bindgen",
+ "windows-core",
+]
+
+[[package]]
+name = "iana-time-zone-haiku"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "icu_collections"
 version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -949,6 +1001,15 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "tempfile",
+]
+
+[[package]]
+name = "num-traits"
+version = "0.2.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
+dependencies = [
+ "autocfg",
 ]
 
 [[package]]
@@ -1854,6 +1915,7 @@ dependencies = [
 name = "trx-cli"
 version = "0.1.12"
 dependencies = [
+ "chrono",
  "color-eyre",
  "directories",
  "flate2",
@@ -2119,6 +2181,41 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "windows-core"
+version = "0.62.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
+dependencies = [
+ "windows-implement",
+ "windows-interface",
+ "windows-link",
+ "windows-result",
+ "windows-strings",
+]
+
+[[package]]
+name = "windows-implement"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "windows-interface"
+version = "0.59.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "windows-link"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,7 @@ toml = "0.8"
 directories = "5.0"
 tempfile = "3.10"
 self-replace = "1.5"
+chrono = "0.4.45"
 
 [profile.release]
 opt-level = "z"     # Optimize for size

--- a/src/history.rs
+++ b/src/history.rs
@@ -49,7 +49,7 @@ pub fn read_entries() -> Vec<String> {
     let reader = BufReader::new(file);
     let mut entries = Vec::new();
 
-    for line in reader.lines().flatten() {
+    for line in reader.lines().map_while(Result::ok) {
         let trimmed = line.trim();
         if !trimmed.is_empty() {
             entries.push(trimmed.to_string());

--- a/src/history.rs
+++ b/src/history.rs
@@ -5,9 +5,10 @@ use std::path::PathBuf;
 
 fn get_history_path() -> Option<PathBuf> {
     if let Ok(state_home) = std::env::var("XDG_STATE_HOME")
-        && !state_home.is_empty() {
-            return Some(PathBuf::from(state_home).join("trx").join("history.log"));
-        }
+        && !state_home.is_empty()
+    {
+        return Some(PathBuf::from(state_home).join("trx").join("history.log"));
+    }
 
     if let Some(base_dirs) = directories::BaseDirs::new() {
         return Some(

--- a/src/history.rs
+++ b/src/history.rs
@@ -4,11 +4,10 @@ use std::io::{BufRead, BufReader, Write};
 use std::path::PathBuf;
 
 fn get_history_path() -> Option<PathBuf> {
-    if let Ok(state_home) = std::env::var("XDG_STATE_HOME") {
-        if !state_home.is_empty() {
+    if let Ok(state_home) = std::env::var("XDG_STATE_HOME")
+        && !state_home.is_empty() {
             return Some(PathBuf::from(state_home).join("trx").join("history.log"));
         }
-    }
 
     if let Some(base_dirs) = directories::BaseDirs::new() {
         return Some(

--- a/src/history.rs
+++ b/src/history.rs
@@ -9,11 +9,13 @@ fn get_history_path() -> Option<PathBuf> {
             return Some(PathBuf::from(state_home).join("trx").join("history.log"));
         }
     }
-    
+
     if let Some(base_dirs) = directories::BaseDirs::new() {
-        return Some(base_dirs.home_dir().join(".local").join("state").join("trx").join("history.log"));
+        return Some(
+            base_dirs.home_dir().join(".local").join("state").join("trx").join("history.log"),
+        );
     }
-    
+
     None
 }
 

--- a/src/history.rs
+++ b/src/history.rs
@@ -1,0 +1,59 @@
+use chrono::Utc;
+use std::fs::{self, OpenOptions};
+use std::io::{BufRead, BufReader, Write};
+use std::path::PathBuf;
+
+fn get_history_path() -> Option<PathBuf> {
+    if let Ok(state_home) = std::env::var("XDG_STATE_HOME") {
+        if !state_home.is_empty() {
+            return Some(PathBuf::from(state_home).join("trx").join("history.log"));
+        }
+    }
+    
+    if let Some(base_dirs) = directories::BaseDirs::new() {
+        return Some(base_dirs.home_dir().join(".local").join("state").join("trx").join("history.log"));
+    }
+    
+    None
+}
+
+pub fn append_entry(action: &str, name: &str, version: &str, manager: &str) {
+    let Some(path) = get_history_path() else {
+        return;
+    };
+
+    if let Some(parent) = path.parent() {
+        let _ = fs::create_dir_all(parent);
+    }
+
+    let timestamp = Utc::now().to_rfc3339();
+    // Use format required: <UTC ISO8601 timestamp>  <ACTION>  <package>  <version>  [<manager>]
+    // Padding to keep it somewhat aligned, though length varies.
+    let entry = format!("{}  {:<8} {:<20} {:<15} [{}]", timestamp, action, name, version, manager);
+
+    if let Ok(mut file) = OpenOptions::new().create(true).append(true).open(path) {
+        let _ = writeln!(file, "{}", entry);
+    }
+}
+
+pub fn read_entries() -> Vec<String> {
+    let Some(path) = get_history_path() else {
+        return Vec::new();
+    };
+
+    let Ok(file) = fs::File::open(path) else {
+        return Vec::new();
+    };
+
+    let reader = BufReader::new(file);
+    let mut entries = Vec::new();
+
+    for line in reader.lines().flatten() {
+        let trimmed = line.trim();
+        if !trimmed.is_empty() {
+            entries.push(trimmed.to_string());
+        }
+    }
+
+    entries
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,6 @@
 mod config;
 mod fuzzy;
+pub mod history;
 mod managers;
 mod ui;
 mod updater;

--- a/src/ui/app.rs
+++ b/src/ui/app.rs
@@ -800,10 +800,11 @@ impl App {
                                             } else if self.current_tab == Tab::History {
                                                 if let Some(selected) =
                                                     self.history_list_state.selected()
-                                                    && selected > 0 {
-                                                        self.history_list_state
-                                                            .select(Some(selected - 1));
-                                                    }
+                                                    && selected > 0
+                                                {
+                                                    self.history_list_state
+                                                        .select(Some(selected - 1));
+                                                }
                                             } else if self.selected > 0 {
                                                 self.selected -= 1;
                                                 self.list_state.select(Some(self.selected));
@@ -823,10 +824,11 @@ impl App {
                                             } else if self.current_tab == Tab::History {
                                                 if let Some(selected) =
                                                     self.history_list_state.selected()
-                                                    && selected + 1 < self.history_entries.len() {
-                                                        self.history_list_state
-                                                            .select(Some(selected + 1));
-                                                    }
+                                                    && selected + 1 < self.history_entries.len()
+                                                {
+                                                    self.history_list_state
+                                                        .select(Some(selected + 1));
+                                                }
                                             } else if self.selected + 1 < self.packages.len() {
                                                 self.selected += 1;
                                                 self.list_state.select(Some(self.selected));

--- a/src/ui/app.rs
+++ b/src/ui/app.rs
@@ -800,12 +800,10 @@ impl App {
                                             } else if self.current_tab == Tab::History {
                                                 if let Some(selected) =
                                                     self.history_list_state.selected()
-                                                {
-                                                    if selected > 0 {
+                                                    && selected > 0 {
                                                         self.history_list_state
                                                             .select(Some(selected - 1));
                                                     }
-                                                }
                                             } else if self.selected > 0 {
                                                 self.selected -= 1;
                                                 self.list_state.select(Some(self.selected));
@@ -825,12 +823,10 @@ impl App {
                                             } else if self.current_tab == Tab::History {
                                                 if let Some(selected) =
                                                     self.history_list_state.selected()
-                                                {
-                                                    if selected + 1 < self.history_entries.len() {
+                                                    && selected + 1 < self.history_entries.len() {
                                                         self.history_list_state
                                                             .select(Some(selected + 1));
                                                     }
-                                                }
                                             } else if self.selected + 1 < self.packages.len() {
                                                 self.selected += 1;
                                                 self.list_state.select(Some(self.selected));

--- a/src/ui/app.rs
+++ b/src/ui/app.rs
@@ -269,11 +269,13 @@ impl App {
         self.manager.install(terminal, &self.selected_names)?;
 
         for name in &self.selected_names {
-            let (version, provider) = self.packages.iter()
+            let (version, provider) = self
+                .packages
+                .iter()
                 .find(|p| &p.name == name)
                 .map(|p| (p.version.as_str(), p.provider.as_str()))
                 .unwrap_or(("unknown", "unknown"));
-            
+
             crate::history::append_entry("INSTALL", name, version, provider);
         }
 
@@ -299,11 +301,13 @@ impl App {
             self.manager.remove(terminal, &to_remove)?;
 
             for name in &to_remove {
-                let (version, provider) = self.packages.iter()
+                let (version, provider) = self
+                    .packages
+                    .iter()
                     .find(|p| &p.name == name)
                     .map(|p| (p.version.as_str(), p.provider.as_str()))
                     .unwrap_or(("unknown", "unknown"));
-                
+
                 crate::history::append_entry("REMOVE", name, version, provider);
             }
         }
@@ -395,7 +399,11 @@ impl App {
                 let mut entries = crate::history::read_entries();
                 entries.reverse(); // latest on top
                 self.history_entries = entries;
-                self.history_list_state.select(if self.history_entries.is_empty() { None } else { Some(0) });
+                self.history_list_state.select(if self.history_entries.is_empty() {
+                    None
+                } else {
+                    Some(0)
+                });
             }
         }
     }
@@ -790,9 +798,12 @@ impl App {
                                                     self.settings_index -= 1;
                                                 }
                                             } else if self.current_tab == Tab::History {
-                                                if let Some(selected) = self.history_list_state.selected() {
+                                                if let Some(selected) =
+                                                    self.history_list_state.selected()
+                                                {
                                                     if selected > 0 {
-                                                        self.history_list_state.select(Some(selected - 1));
+                                                        self.history_list_state
+                                                            .select(Some(selected - 1));
                                                     }
                                                 }
                                             } else if self.selected > 0 {
@@ -812,9 +823,12 @@ impl App {
                                                     self.settings_index += 1;
                                                 }
                                             } else if self.current_tab == Tab::History {
-                                                if let Some(selected) = self.history_list_state.selected() {
+                                                if let Some(selected) =
+                                                    self.history_list_state.selected()
+                                                {
                                                     if selected + 1 < self.history_entries.len() {
-                                                        self.history_list_state.select(Some(selected + 1));
+                                                        self.history_list_state
+                                                            .select(Some(selected + 1));
                                                     }
                                                 }
                                             } else if self.selected + 1 < self.packages.len() {
@@ -840,7 +854,9 @@ impl App {
                                         KeyCode::End => {
                                             if self.current_tab == Tab::History {
                                                 if !self.history_entries.is_empty() {
-                                                    self.history_list_state.select(Some(self.history_entries.len() - 1));
+                                                    self.history_list_state.select(Some(
+                                                        self.history_entries.len() - 1,
+                                                    ));
                                                 }
                                             } else if !self.packages.is_empty() {
                                                 self.selected = self.packages.len() - 1;

--- a/src/ui/app.rs
+++ b/src/ui/app.rs
@@ -21,6 +21,7 @@ pub enum Tab {
     Search,
     Installed,
     Updates,
+    History,
     Settings,
 }
 
@@ -67,8 +68,10 @@ pub struct App {
     update_check_in_flight: Arc<AtomicBool>,
     last_input_time: Instant,
     pending_search: bool,
-    last_search_query: String,
+    pub last_search_query: String,
     pub popup_timer: Option<Instant>,
+    pub history_entries: Vec<String>,
+    pub history_list_state: ListState,
 }
 
 impl App {
@@ -139,6 +142,8 @@ impl App {
             last_input_time: Instant::now(),
             pending_search: false,
             last_search_query: String::new(),
+            history_entries: Vec::new(),
+            history_list_state: ListState::default(),
         };
 
         if app.current_tab != Tab::Search {
@@ -261,7 +266,18 @@ impl App {
             return Ok(());
         }
 
-        self.manager.install(terminal, &self.selected_names)
+        self.manager.install(terminal, &self.selected_names)?;
+
+        for name in &self.selected_names {
+            let (version, provider) = self.packages.iter()
+                .find(|p| &p.name == name)
+                .map(|p| (p.version.as_str(), p.provider.as_str()))
+                .unwrap_or(("unknown", "unknown"));
+            
+            crate::history::append_entry("INSTALL", name, version, provider);
+        }
+
+        Ok(())
     }
 
     fn run_remove_command(
@@ -281,6 +297,15 @@ impl App {
 
         if !to_remove.is_empty() {
             self.manager.remove(terminal, &to_remove)?;
+
+            for name in &to_remove {
+                let (version, provider) = self.packages.iter()
+                    .find(|p| &p.name == name)
+                    .map(|p| (p.version.as_str(), p.provider.as_str()))
+                    .unwrap_or(("unknown", "unknown"));
+                
+                crate::history::append_entry("REMOVE", name, version, provider);
+            }
         }
 
         Ok(())
@@ -310,7 +335,8 @@ impl App {
         self.current_tab = match self.current_tab {
             Tab::Search => Tab::Installed,
             Tab::Installed => Tab::Updates,
-            Tab::Updates => Tab::Settings,
+            Tab::Updates => Tab::History,
+            Tab::History => Tab::Settings,
             Tab::Settings => Tab::Search,
         };
 
@@ -322,7 +348,8 @@ impl App {
             Tab::Search => Tab::Settings,
             Tab::Installed => Tab::Search,
             Tab::Updates => Tab::Installed,
-            Tab::Settings => Tab::Updates,
+            Tab::History => Tab::Updates,
+            Tab::Settings => Tab::History,
         };
 
         self.reset_tab_state();
@@ -362,6 +389,13 @@ impl App {
             }
             Tab::Settings => {
                 self.loading = false;
+            }
+            Tab::History => {
+                self.loading = false;
+                let mut entries = crate::history::read_entries();
+                entries.reverse(); // latest on top
+                self.history_entries = entries;
+                self.history_list_state.select(if self.history_entries.is_empty() { None } else { Some(0) });
             }
         }
     }
@@ -440,7 +474,7 @@ impl App {
     }
 
     fn next_default_tab(&mut self) {
-        let tabs = ["Search", "Installed", "Updates", "Settings"];
+        let tabs = ["Search", "Installed", "Updates", "History", "Settings"];
         let current_pos =
             tabs.iter().position(|&t| t == self.config.settings.default_tab).unwrap_or(0);
         let next_pos = (current_pos + 1) % tabs.len();
@@ -450,7 +484,7 @@ impl App {
     }
 
     fn prev_default_tab(&mut self) {
-        let tabs = ["Search", "Installed", "Updates", "Settings"];
+        let tabs = ["Search", "Installed", "Updates", "History", "Settings"];
         let current_pos =
             tabs.iter().position(|&t| t == self.config.settings.default_tab).unwrap_or(0);
         let next_pos = if current_pos == 0 { tabs.len() - 1 } else { current_pos - 1 };
@@ -536,6 +570,7 @@ impl App {
                     Tab::Search => q == self.input.trim(),
                     Tab::Installed => q == "__INSTALLED__",
                     Tab::Updates => q == "__UPDATES__",
+                    Tab::History => false,
                     Tab::Settings => false,
                 };
 
@@ -754,6 +789,12 @@ impl App {
                                                 if self.settings_index > 0 {
                                                     self.settings_index -= 1;
                                                 }
+                                            } else if self.current_tab == Tab::History {
+                                                if let Some(selected) = self.history_list_state.selected() {
+                                                    if selected > 0 {
+                                                        self.history_list_state.select(Some(selected - 1));
+                                                    }
+                                                }
                                             } else if self.selected > 0 {
                                                 self.selected -= 1;
                                                 self.list_state.select(Some(self.selected));
@@ -770,6 +811,12 @@ impl App {
                                                 if self.settings_index < max {
                                                     self.settings_index += 1;
                                                 }
+                                            } else if self.current_tab == Tab::History {
+                                                if let Some(selected) = self.history_list_state.selected() {
+                                                    if selected + 1 < self.history_entries.len() {
+                                                        self.history_list_state.select(Some(selected + 1));
+                                                    }
+                                                }
                                             } else if self.selected + 1 < self.packages.len() {
                                                 self.selected += 1;
                                                 self.list_state.select(Some(self.selected));
@@ -779,15 +826,27 @@ impl App {
                                         KeyCode::Enter if self.current_tab == Tab::Settings => {
                                             self.handle_settings_toggle();
                                         }
-                                        KeyCode::Home if !self.packages.is_empty() => {
-                                            self.selected = 0;
-                                            self.list_state.select(Some(self.selected));
-                                            self.trigger_details_fetch();
+                                        KeyCode::Home => {
+                                            if self.current_tab == Tab::History {
+                                                if !self.history_entries.is_empty() {
+                                                    self.history_list_state.select(Some(0));
+                                                }
+                                            } else if !self.packages.is_empty() {
+                                                self.selected = 0;
+                                                self.list_state.select(Some(self.selected));
+                                                self.trigger_details_fetch();
+                                            }
                                         }
-                                        KeyCode::End if !self.packages.is_empty() => {
-                                            self.selected = self.packages.len() - 1;
-                                            self.list_state.select(Some(self.selected));
-                                            self.trigger_details_fetch();
+                                        KeyCode::End => {
+                                            if self.current_tab == Tab::History {
+                                                if !self.history_entries.is_empty() {
+                                                    self.history_list_state.select(Some(self.history_entries.len() - 1));
+                                                }
+                                            } else if !self.packages.is_empty() {
+                                                self.selected = self.packages.len() - 1;
+                                                self.list_state.select(Some(self.selected));
+                                                self.trigger_details_fetch();
+                                            }
                                         }
                                         _ => {}
                                     }

--- a/src/ui/app.rs
+++ b/src/ui/app.rs
@@ -1052,7 +1052,7 @@ impl App {
                     }
                 } else if self.current_tab == Tab::Search && (4..=6).contains(&mouse_event.row) {
                     let is_wide = term_width >= 100;
-                    if (is_wide && mouse_event.column < term_width / 2) || !is_wide {
+                    if !is_wide || mouse_event.column < term_width / 2 {
                         self.input_mode = InputMode::Editing;
                         self.character_index = self.input.chars().count();
                         return Ok(());

--- a/src/ui/app.rs
+++ b/src/ui/app.rs
@@ -84,7 +84,7 @@ pub struct App {
     pub popup_timer: Option<Instant>,
     pub history_entries: Vec<String>,
     pub history_list_state: ListState,
-    last_search_query: String,
+
     search_input_mode: InputMode,
 }
 
@@ -159,6 +159,7 @@ impl App {
             last_input_time: Instant::now(),
             pending_search: false,
             last_search_query: String::new(),
+            popup_timer: None,
             history_entries: Vec::new(),
             history_list_state: ListState::default(),
             search_input_mode: InputMode::Editing,
@@ -1064,8 +1065,7 @@ impl App {
                     }
                     let r = mouse_event.row;
                     let mgr_count = self.available_managers.len() as u16;
-                    let has_config_path =
-                        directories::ProjectDirs::from("", "", "trx").is_some();
+                    let has_config_path = directories::ProjectDirs::from("", "", "trx").is_some();
 
                     let (general_start, mgrs_start, aesthetics_start, colors_start) =
                         if has_config_path {

--- a/src/ui/draw.rs
+++ b/src/ui/draw.rs
@@ -64,6 +64,8 @@ pub fn draw_ui(frame: &mut Frame, app: &mut App) {
 
     if let crate::ui::app::Tab::Settings = app.current_tab {
         draw_settings_tab(frame, app, content_area, &theme_colors);
+    } else if let crate::ui::app::Tab::History = app.current_tab {
+        draw_history_tab(frame, app, content_area, &theme_colors);
     } else {
         // Responsive layout for content area
         let is_wide = content_area.width >= 100;
@@ -202,7 +204,7 @@ fn draw_tabs(frame: &mut Frame, app: &App, area: Rect, theme: &crate::config::Th
     let highlight_color = app.config.get_color(&theme.highlight_color);
     let border_type = get_border_type(&app.config.settings.border_style);
 
-    let tab_titles = vec!["Search", "Installed", "Updates", "Settings"];
+    let tab_titles = vec!["Search", "Installed", "Updates", "History", "Settings"];
     let tabs = ratatui::widgets::Tabs::new(tab_titles)
         .block(
             Block::bordered()
@@ -214,7 +216,8 @@ fn draw_tabs(frame: &mut Frame, app: &App, area: Rect, theme: &crate::config::Th
             crate::ui::app::Tab::Search => 0,
             crate::ui::app::Tab::Installed => 1,
             crate::ui::app::Tab::Updates => 2,
-            crate::ui::app::Tab::Settings => 3,
+            crate::ui::app::Tab::History => 3,
+            crate::ui::app::Tab::Settings => 4,
         })
         .highlight_style(Style::default().fg(highlight_color).add_modifier(Modifier::BOLD));
     frame.render_widget(tabs, area);
@@ -384,6 +387,57 @@ fn draw_settings_tab(frame: &mut Frame, app: &App, area: Rect, theme: &crate::co
         .wrap(Wrap { trim: false });
 
     frame.render_widget(paragraph, area);
+}
+
+fn draw_history_tab(frame: &mut Frame, app: &mut App, area: Rect, theme: &crate::config::Theme) {
+    let highlight_bg = app.config.get_color(&theme.highlight_color);
+    let highlight_fg = crate::config::Config::contrast_fg_for(highlight_bg);
+    let primary_color = app.config.get_color(&theme.text_primary);
+    let secondary_color = app.config.get_color(&theme.text_secondary);
+    let success_color = app.config.get_color(&theme.success_color);
+    let error_color = app.config.get_color(&theme.error_color);
+    let border_color = app.config.get_color(&theme.border_color);
+    let border_type = get_border_type(&app.config.settings.border_style);
+
+    let items: Vec<ListItem> = if app.history_entries.is_empty() {
+        vec![ListItem::new(Line::from(Span::styled(
+            "  No history yet \u{2014} install or remove a package to begin tracking.",
+            Style::default().fg(secondary_color).add_modifier(Modifier::ITALIC),
+        )))]
+    } else {
+        app.history_entries
+            .iter()
+            .map(|entry| {
+                let is_install = entry.contains(" INSTALL ");
+                let is_remove = entry.contains(" REMOVE ");
+                let mut style = Style::default().fg(primary_color);
+                
+                // Color code the action part
+                if is_install {
+                    style = style.fg(success_color);
+                } else if is_remove {
+                    style = style.fg(error_color);
+                }
+
+                ListItem::new(Line::from(Span::styled(entry, style)))
+            })
+            .collect()
+    };
+
+    let title = format!(" History ({}) ", app.history_entries.len());
+    let list = List::new(items)
+        .block(
+            Block::bordered()
+                .title(title)
+                .border_type(border_type)
+                .border_style(Style::default().fg(border_color)),
+        )
+        .highlight_style(
+            Style::default().bg(highlight_bg).fg(highlight_fg).add_modifier(Modifier::BOLD),
+        )
+        .highlight_symbol(">> ");
+
+    frame.render_stateful_widget(list, area, &mut app.history_list_state);
 }
 
 fn draw_status_bar(frame: &mut Frame, app: &App, area: Rect, theme: &crate::config::Theme) {

--- a/src/ui/draw.rs
+++ b/src/ui/draw.rs
@@ -411,7 +411,7 @@ fn draw_history_tab(frame: &mut Frame, app: &mut App, area: Rect, theme: &crate:
                 let is_install = entry.contains(" INSTALL ");
                 let is_remove = entry.contains(" REMOVE ");
                 let mut style = Style::default().fg(primary_color);
-                
+
                 // Color code the action part
                 if is_install {
                     style = style.fg(success_color);


### PR DESCRIPTION
Resolves #58

## 📝 Details
This PR introduces a persistent history log and a new **History** tab in the TUI, allowing users to easily track what packages were installed or removed over time. 

- **Persistent Logging (`src/history.rs`)**: Securely tracks and writes `install` and `remove` events to `~/.local/state/trx/history.log` (or respects `$XDG_STATE_HOME` if set).
- **Structured Timestamps**: Integrated the `chrono` dependency to utilize precise UTC ISO8601 timestamps.
- **TUI History Tab (`src/ui/app.rs` & `src/ui/draw.rs`)**: 
  - Added a dedicated `History` tab cleanly integrated into the navigation cycle.
  - Renders a backwards-chronological log (newest events appear at the top).
  - Handles missing log files gracefully with a helpful fallback message.
  - Fully scrollable using standard navigational keys (`k`/`j`, `Up`/`Down`, `Home`/`End`).
  - Implemented dynamic color-coding (Success green for `INSTALL`, Error red for `REMOVE`).

## 📸 Screenshots
<img width="1920" height="1080" alt="Screenshot (401)" src="https://github.com/user-attachments/assets/abc4fb01-bae9-45b9-b7ab-d1fd4ef562e2" />
<img width="1920" height="1080" alt="Screenshot (403)" src="https://github.com/user-attachments/assets/8e4a79f1-e79f-4edd-a893-d67755de9ae9" />
<img width="1920" height="1080" alt="Screenshot (405)" src="https://github.com/user-attachments/assets/3e546278-a067-4fc8-b0a5-7c58e01840ed" />


## 🔄 Reproducibility
To test this feature locally:
1. Switch to this branch and run `cargo run`.
2. Navigate to the **History** tab to observe the empty state fallback.
3. Install a package via the **Search** tab.
4. Remove a package via the **Installed** tab.
5. Navigate back to the **History** tab to verify that both events were logged correctly, color-coded, and are scrollable.