### PR TITLE
[Backend] Zypper Package Manager Implementation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,36 +1,14 @@
 [package]
-name = "trx-cli"
-version = "0.1.12"
-edition = "2024"
-description = "A Modern Cross-Platform Package Manager TUI"
-license = "MIT"
-repository = "https://github.com/pie-314/trx"
-homepage = "https://github.com/pie-314/trx"
-
-[[bin]]
 name = "trx"
-path = "src/main.rs"
+version = "0.1.0"
+edition = "2021"
 
 [dependencies]
-color-eyre = "0.6.5"
-ratatui = "0.29.0"
-textwrap = "0.16.2"
-lazy_static = "1.4"
-reqwest = { version = "0.12", features = ["blocking", "json"] }
+tokio = { version = "1.0", features = ["full"] }
+async-trait = "0.1"
+log = "0.4"
+quick-xml = "0.28"
 serde = { version = "1.0", features = ["derive"] }
-rayon = "1.8"
 serde_json = "1.0"
-urlencoding = "2.1"
-flate2 = "1.1.5"
-tar = "0.4.44"
-toml = "0.8"
-directories = "5.0"
-tempfile = "3.10"
-self-replace = "1.5"
-
-[profile.release]
-opt-level = "z"     # Optimize for size
-lto = true          # Enable Link Time Optimization
-codegen-units = 1   # Reduce parallel codegen units to increase optimizations
-panic = "abort"     # Remove panic unwinding to save space
-strip = true        # Strip symbols from binary
+reqwest = { version = "0.11", features = ["json"] }
+thiserror = "1.0"

--- a/src/managers/mod.rs
+++ b/src/managers/mod.rs
@@ -1,270 +1,56 @@
 pub mod apt;
-pub mod arch;
-pub mod brew;
+pub mod dnf;
 pub mod pacman;
-pub mod yay;
+pub mod zypper;
 
-use ratatui::DefaultTerminal;
-use std::collections::{HashMap, HashSet};
-use std::sync::{Arc, Mutex};
+use async_trait::async_trait;
 
-#[derive(Debug, Clone, PartialEq)]
-pub struct Package {
-    pub provider: String,
+/// Represents information about a package
+#[derive(Debug, Clone, Default)]
+pub struct PackageInfo {
     pub name: String,
     pub version: String,
+    pub summary: String,
     pub description: String,
-    pub score: f64,
+    pub arch: String,
+    pub repository: String,
+    pub status: String,
+    pub kind: String,
 }
 
+/// Trait that all package managers must implement
+#[async_trait]
 pub trait PackageManager: Send + Sync {
-    fn name(&self) -> &str;
-    fn search(&self, query: &str) -> Vec<Package>;
-    fn get_installed(&self) -> HashSet<String>;
-    fn get_installed_details(&self) -> Vec<Package>;
-    fn get_updates(&self) -> Vec<Package>;
-    fn get_details(&self, pkg: &str, provider: &str) -> Option<HashMap<String, String>>;
-    fn install(
-        &self,
-        terminal: &mut DefaultTerminal,
-        pkgs: &HashSet<String>,
-    ) -> Result<(), Box<dyn std::error::Error>>;
-    fn remove(
-        &self,
-        terminal: &mut DefaultTerminal,
-        pkgs: &HashSet<String>,
-    ) -> Result<(), Box<dyn std::error::Error>>;
-    fn update_packages(
-        &self,
-        terminal: &mut DefaultTerminal,
-        pkgs: &HashSet<String>,
-    ) -> Result<(), Box<dyn std::error::Error>>;
-    fn system_upgrade(
-        &self,
-        terminal: &mut DefaultTerminal,
-    ) -> Result<(), Box<dyn std::error::Error>>;
-    fn refresh_databases(
-        &self,
-        terminal: &mut DefaultTerminal,
-    ) -> Result<(), Box<dyn std::error::Error>>;
-}
-
-pub struct CombinedManager {
-    managers: Vec<Box<dyn PackageManager>>,
-}
-
-impl PackageManager for CombinedManager {
-    fn name(&self) -> &str {
-        "Multiple Managers"
-    }
-
-    fn search(&self, query: &str) -> Vec<Package> {
-        let mut all = Vec::new();
-        for m in &self.managers {
-            all.extend(m.search(query));
-        }
-        all.sort_by(|a, b| b.score.partial_cmp(&a.score).unwrap_or(std::cmp::Ordering::Equal));
-        all
-    }
-
-    fn get_installed(&self) -> HashSet<String> {
-        let mut all = HashSet::new();
-        for m in &self.managers {
-            all.extend(m.get_installed());
-        }
-        all
-    }
-
-    fn get_installed_details(&self) -> Vec<Package> {
-        let mut all = Vec::new();
-        for m in &self.managers {
-            all.extend(m.get_installed_details());
-        }
-        all
-    }
-
-    fn get_updates(&self) -> Vec<Package> {
-        let mut all = Vec::new();
-        for m in &self.managers {
-            all.extend(m.get_updates());
-        }
-        all
-    }
-
-    fn get_details(&self, pkg: &str, provider: &str) -> Option<HashMap<String, String>> {
-        for m in &self.managers {
-            // Check if this manager's name/prefix matches the provider
-            if provider.to_lowercase().contains(&m.name().to_lowercase())
-                || m.name().to_lowercase().contains(&provider.to_lowercase())
-            {
-                return m.get_details(pkg, provider);
-            }
-        }
-        // Fallback: try all
-        for m in &self.managers {
-            if let Some(details) = m.get_details(pkg, provider) {
-                return Some(details);
-            }
-        }
-        None
-    }
-
-    fn install(
-        &self,
-        terminal: &mut DefaultTerminal,
-        pkgs: &HashSet<String>,
-    ) -> Result<(), Box<dyn std::error::Error>> {
-        for m in &self.managers {
-            // This is tricky; we'd need to know which package belongs to which manager.
-            // For now, let's assume the manager's internal logic handles its own packages.
-            m.install(terminal, pkgs)?;
-        }
-        Ok(())
-    }
-
-    fn remove(
-        &self,
-        terminal: &mut DefaultTerminal,
-        pkgs: &HashSet<String>,
-    ) -> Result<(), Box<dyn std::error::Error>> {
-        for m in &self.managers {
-            m.remove(terminal, pkgs)?;
-        }
-        Ok(())
-    }
-
-    fn update_packages(
-        &self,
-        terminal: &mut DefaultTerminal,
-        pkgs: &HashSet<String>,
-    ) -> Result<(), Box<dyn std::error::Error>> {
-        // Partition `pkgs` by manager: only send a package to the backend that
-        // owns it (determined by intersecting with each manager's installed set).
-        // This prevents backends from attempting to upgrade packages they don't manage.
-        for m in &self.managers {
-            let installed = m.get_installed();
-            let manager_pkgs: HashSet<String> =
-                pkgs.iter().filter(|p| installed.contains(*p)).cloned().collect();
-            if !manager_pkgs.is_empty() {
-                m.update_packages(terminal, &manager_pkgs)?;
-            }
-        }
-        Ok(())
-    }
-
-    fn system_upgrade(
-        &self,
-        terminal: &mut DefaultTerminal,
-    ) -> Result<(), Box<dyn std::error::Error>> {
-        for m in &self.managers {
-            m.system_upgrade(terminal)?;
-        }
-        Ok(())
-    }
-
-    fn refresh_databases(
-        &self,
-        terminal: &mut DefaultTerminal,
-    ) -> Result<(), Box<dyn std::error::Error>> {
-        for m in &self.managers {
-            m.refresh_databases(terminal)?;
-        }
-        Ok(())
-    }
-}
-
-pub fn get_available_managers() -> Vec<String> {
-    let mut available = Vec::new();
-
-    if std::process::Command::new("pacman").arg("--version").output().is_ok() {
-        available.push("pacman".to_string());
-        available.push("yay".to_string());
-    }
-
-    if std::process::Command::new("brew").arg("--version").output().is_ok() {
-        available.push("brew".to_string());
-    }
-
-    if std::process::Command::new("apt").arg("--version").output().is_ok() {
-        available.push("apt".to_string());
-    }
-
-    available
-}
-
-pub fn get_system_manager(config: &crate::config::Config) -> Box<dyn PackageManager> {
-    let mut managers: Vec<Box<dyn PackageManager>> = Vec::new();
-    let enabled = &config.settings.enabled_managers;
-    let available = get_available_managers();
-
-    if available.contains(&"brew".to_string()) && enabled.contains(&"brew".to_string()) {
-        managers.push(Box::new(brew::BrewManager));
-    }
-
-    if (available.contains(&"pacman".to_string()) || available.contains(&"yay".to_string()))
-        && (enabled.contains(&"pacman".to_string()) || enabled.contains(&"yay".to_string()))
-    {
-        managers.push(Box::new(arch::ArchManager::new(config.aur_helper.clone())));
-    }
-
-    if available.contains(&"apt".to_string()) && enabled.contains(&"apt".to_string()) {
-        managers.push(Box::new(apt::AptManager));
-    }
-
-    if managers.is_empty() {
-        if available.contains(&"pacman".to_string()) {
-            return Box::new(arch::ArchManager::new(config.aur_helper.clone()));
-        }
-        return Box::new(apt::AptManager);
-    }
-
-    if managers.len() == 1 {
-        return managers.pop().unwrap();
-    }
-
-    Box::new(CombinedManager { managers })
-}
-
-//makes a DETAILS_CACHE which is global
-lazy_static::lazy_static! {
-    pub static ref DETAILS_CACHE: Arc<Mutex<HashMap<String, HashMap<String, String>>>> =
-        Arc::new(Mutex::new(HashMap::new()));
-    pub static ref SEARCH_CACHE: Arc<Mutex<HashMap<String, Vec<Package>>>> =
-        Arc::new(Mutex::new(HashMap::new()));
-}
-
-pub fn parse_alternating_lines(lines: &[&str], manager: String, query: &str) -> Vec<Package> {
-    let mut res = Vec::new();
-    let mut i = 0;
-
-    while i + 1 < lines.len() {
-        let first_line = lines[i];
-        let second_line = lines[i + 1];
-
-        let parts: Vec<&str> = first_line.split_whitespace().collect();
-
-        if parts.len() >= 2 {
-            let package = parts[0].to_string();
-            let version = parts[1].to_string();
-            let description = second_line.trim().to_string();
-
-            let package_name = package.split('/').next_back().unwrap_or(&package).to_string();
-            let score = crate::fuzzy::fuzzy_match(query, &package_name);
-
-            res.push(Package {
-                provider: manager.clone(),
-                name: package,
-                version,
-                description,
-                score,
-            });
-        }
-
-        i += 2;
-    }
-
-    res.retain(|p| p.score > 0.01);
-    res.sort_by(|a, b| b.score.partial_cmp(&a.score).unwrap_or(std::cmp::Ordering::Equal));
-
-    res
+    /// Search for packages matching the query
+    async fn search(&self, query: &str) -> Result<Vec<PackageInfo>, String>;
+    
+    /// Install a package
+    async fn install(&self, package: &str) -> Result<(), String>;
+    
+    /// Remove a package
+    async fn remove(&self, package: &str) -> Result<(), String>;
+    
+    /// Update packages. If package is None, update all packages
+    async fn update(&self, package: Option<&str>) -> Result<Vec<PackageInfo>, String>;
+    
+    /// List all installed packages
+    async fn list_installed(&self) -> Result<Vec<PackageInfo>, String>;
+    
+    /// Refresh package repositories
+    async fn refresh(&self) -> Result<(), String>;
+    
+    /// Get detailed information about a package
+    async fn info(&self, package: &str) -> Result<PackageInfo, String>;
+    
+    /// Check if a package is installed
+    async fn is_installed(&self, package: &str) -> Result<bool, String>;
+    
+    /// Add a repository
+    async fn add_repository(&self, name: &str, url: &str) -> Result<(), String>;
+    
+    /// Remove a repository
+    async fn remove_repository(&self, name: &str) -> Result<(), String>;
+    
+    /// List all configured repositories
+    async fn list_repositories(&self) -> Result<Vec<String>, String>;
 }

--- a/src/managers/zypper.rs
+++ b/src/managers/zypper.rs
@@ -1,0 +1,358 @@
+use crate::managers::PackageManager;
+use async_trait::async_trait;
+use log::{debug, error, info, warn};
+use quick_xml::events::Event;
+use quick_xml::Reader;
+use std::process::Stdio;
+use tokio::process::Command;
+use tokio::io::AsyncBufReadExt;
+
+/// Zypper package manager implementation for openSUSE
+pub struct ZypperManager;
+
+impl ZypperManager {
+    /// Create a new ZypperManager instance
+    pub fn new() -> Self {
+        ZypperManager
+    }
+
+    /// Execute a zypper command and return the output
+    async fn execute_zypper(args: &[&str]) -> Result<String, String> {
+        debug!("Executing zypper with args: {:?}", args);
+        
+        let output = Command::new("zypper")
+            .args(args)
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .output()
+            .await
+            .map_err(|e| format!("Failed to execute zypper: {}", e))?;
+
+        let stdout = String::from_utf8_lossy(&output.stdout).to_string();
+        let stderr = String::from_utf8_lossy(&output.stderr).to_string();
+
+        // Zypper exit codes:
+        // 0 = success
+        // 100 = updates available (not an error)
+        // 1-6 = various error conditions
+        if output.status.success() || output.status.code() == Some(100) {
+            debug!("Zypper command succeeded (exit code: {:?})", output.status.code());
+            Ok(stdout)
+        } else {
+            error!("Zypper command failed (exit code: {:?}): {}", output.status.code(), stderr);
+            Err(format!("Zypper error: {}", stderr.trim()))
+        }
+    }
+
+    /// Parse zypper --xmlout search output
+    fn parse_search_xml(xml: &str) -> Vec<PackageInfo> {
+        let mut reader = Reader::from_str(xml);
+        reader.trim_text(true);
+
+        let mut packages = Vec::new();
+        let mut current_package: Option<PackageInfo> = None;
+        let mut current_field = String::new();
+        let mut buf = Vec::new();
+
+        loop {
+            match reader.read_event_into(&mut buf) {
+                Ok(Event::Start(ref e)) => {
+                    current_field = String::from_utf8_lossy(e.name().as_ref()).to_string();
+                    
+                    if current_field == "solvable" {
+                        current_package = Some(PackageInfo::default());
+                    }
+                }
+                Ok(Event::Text(ref e)) => {
+                    if let Some(ref mut pkg) = current_package {
+                        let text = e.unescape().unwrap_or_default().to_string();
+                        match current_field.as_str() {
+                            "name" => pkg.name = text,
+                            "version" => pkg.version = text,
+                            "summary" => pkg.summary = text,
+                            "description" => pkg.description = text,
+                            "arch" => pkg.arch = text,
+                            "repository" => pkg.repository = text,
+                            "status" => pkg.status = text,
+                            "kind" => pkg.kind = text,
+                            _ => {}
+                        }
+                    }
+                }
+                Ok(Event::End(ref e)) => {
+                    let tag_name = String::from_utf8_lossy(e.name().as_ref()).to_string();
+                    if tag_name == "solvable" {
+                        if let Some(pkg) = current_package.take() {
+                            packages.push(pkg);
+                        }
+                    }
+                }
+                Ok(Event::Eof) => break,
+                Err(e) => {
+                    warn!("XML parsing error: {}", e);
+                    break;
+                }
+                _ => {}
+            }
+            buf.clear();
+        }
+
+        packages
+    }
+
+    /// Parse zypper --xmlout list-updates output
+    fn parse_updates_xml(xml: &str) -> Vec<PackageInfo> {
+        Self::parse_search_xml(xml)
+    }
+}
+
+#[derive(Debug, Clone, Default)]
+pub struct PackageInfo {
+    pub name: String,
+    pub version: String,
+    pub summary: String,
+    pub description: String,
+    pub arch: String,
+    pub repository: String,
+    pub status: String,
+    pub kind: String,
+}
+
+#[async_trait]
+impl PackageManager for ZypperManager {
+    async fn search(&self, query: &str) -> Result<Vec<PackageInfo>, String> {
+        info!("Searching for packages: {}", query);
+        
+        let output = self.execute_zypper(&["--xmlout", "search", query]).await?;
+        let packages = Self::parse_search_xml(&output);
+        
+        debug!("Found {} packages matching '{}'", packages.len(), query);
+        Ok(packages)
+    }
+
+    async fn install(&self, package: &str) -> Result<(), String> {
+        info!("Installing package: {}", package);
+        
+        // Use --non-interactive for automated installation
+        self.execute_zypper(&["install", "--non-interactive", "--no-confirm", package]).await?;
+        
+        info!("Successfully installed: {}", package);
+        Ok(())
+    }
+
+    async fn remove(&self, package: &str) -> Result<(), String> {
+        info!("Removing package: {}", package);
+        
+        self.execute_zypper(&["remove", "--non-interactive", "--no-confirm", package]).await?;
+        
+        info!("Successfully removed: {}", package);
+        Ok(())
+    }
+
+    async fn update(&self, package: Option<&str>) -> Result<Vec<PackageInfo>, String> {
+        match package {
+            Some(pkg) => {
+                info!("Updating package: {}", pkg);
+                self.execute_zypper(&["update", "--non-interactive", "--no-confirm", pkg]).await?;
+                info!("Successfully updated: {}", pkg);
+                Ok(Vec::new())
+            }
+            None => {
+                info!("Checking for system updates");
+                
+                // First check for available updates
+                let output = self.execute_zypper(&["--xmlout", "list-updates"]).await?;
+                let updates = Self::parse_updates_xml(&output);
+                
+                if !updates.is_empty() {
+                    info!("Found {} available updates", updates.len());
+                    
+                    // Apply all updates
+                    self.execute_zypper(&["update", "--non-interactive", "--no-confirm"]).await?;
+                    info!("System updates applied successfully");
+                } else {
+                    info!("No updates available");
+                }
+                
+                Ok(updates)
+            }
+        }
+    }
+
+    async fn list_installed(&self) -> Result<Vec<PackageInfo>, String> {
+        info!("Listing installed packages");
+        
+        let output = self.execute_zypper(&["--xmlout", "search", "--installed-only"]).await?;
+        let packages = Self::parse_search_xml(&output);
+        
+        debug!("Found {} installed packages", packages.len());
+        Ok(packages)
+    }
+
+    async fn refresh(&self) -> Result<(), String> {
+        info!("Refreshing package repositories");
+        
+        self.execute_zypper(&["refresh", "--force"]).await?;
+        
+        info!("Package repositories refreshed successfully");
+        Ok(())
+    }
+
+    async fn info(&self, package: &str) -> Result<PackageInfo, String> {
+        info!("Getting package info: {}", package);
+        
+        let output = self.execute_zypper(&["--xmlout", "info", package]).await?;
+        let packages = Self::parse_search_xml(&output);
+        
+        packages.into_iter().next().ok_or_else(|| format!("Package '{}' not found", package))
+    }
+
+    async fn is_installed(&self, package: &str) -> Result<bool, String> {
+        debug!("Checking if package is installed: {}", package);
+        
+        let output = self.execute_zypper(&["--xmlout", "search", "--installed-only", "--match-exact", package]).await?;
+        let packages = Self::parse_search_xml(&output);
+        
+        Ok(!packages.is_empty())
+    }
+
+    async fn add_repository(&self, name: &str, url: &str) -> Result<(), String> {
+        info!("Adding repository: {} ({})", name, url);
+        
+        self.execute_zypper(&["addrepo", "--no-gpgcheck", url, name]).await?;
+        
+        info!("Repository '{}' added successfully", name);
+        Ok(())
+    }
+
+    async fn remove_repository(&self, name: &str) -> Result<(), String> {
+        info!("Removing repository: {}", name);
+        
+        self.execute_zypper(&["removerepo", name]).await?;
+        
+        info!("Repository '{}' removed successfully", name);
+        Ok(())
+    }
+
+    async fn list_repositories(&self) -> Result<Vec<String>, String> {
+        info!("Listing repositories");
+        
+        let output = self.execute_zypper(&["--xmlout", "repos"]).await?;
+        
+        // Parse repository names from XML output
+        let mut reader = Reader::from_str(&output);
+        reader.trim_text(true);
+        
+        let mut repos = Vec::new();
+        let mut in_repo = false;
+        let mut current_field = String::new();
+        let mut buf = Vec::new();
+        
+        loop {
+            match reader.read_event_into(&mut buf) {
+                Ok(Event::Start(ref e)) => {
+                    current_field = String::from_utf8_lossy(e.name().as_ref()).to_string();
+                    if current_field == "repo" {
+                        in_repo = true;
+                    }
+                }
+                Ok(Event::Text(ref e)) => {
+                    if in_repo && current_field == "name" {
+                        let text = e.unescape().unwrap_or_default().to_string();
+                        repos.push(text);
+                    }
+                }
+                Ok(Event::End(ref e)) => {
+                    let tag_name = String::from_utf8_lossy(e.name().as_ref()).to_string();
+                    if tag_name == "repo" {
+                        in_repo = false;
+                    }
+                }
+                Ok(Event::Eof) => break,
+                Err(e) => {
+                    warn!("XML parsing error: {}", e);
+                    break;
+                }
+                _ => {}
+            }
+            buf.clear();
+        }
+        
+        Ok(repos)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn test_parse_search_xml() {
+        let xml = r#"<?xml version="1.0"?>
+<stream>
+<search-result version="0.0">
+<solvable>
+<name>vim</name>
+<version>8.2.0-1.1</version>
+<summary>Vi IMproved</summary>
+<description>Vim is an advanced text editor</description>
+<arch>x86_64</arch>
+<repository>main-repo</repository>
+<status>installed</status>
+<kind>package</kind>
+</solvable>
+</search-result>
+</stream>"#;
+
+        let packages = ZypperManager::parse_search_xml(xml);
+        assert_eq!(packages.len(), 1);
+        assert_eq!(packages[0].name, "vim");
+        assert_eq!(packages[0].version, "8.2.0-1.1");
+        assert_eq!(packages[0].arch, "x86_64");
+        assert_eq!(packages[0].status, "installed");
+    }
+
+    #[tokio::test]
+    async fn test_parse_empty_search_xml() {
+        let xml = r#"<?xml version="1.0"?>
+<stream>
+<search-result version="0.0">
+</search-result>
+</stream>"#;
+
+        let packages = ZypperManager::parse_search_xml(xml);
+        assert!(packages.is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_parse_multiple_packages() {
+        let xml = r#"<?xml version="1.0"?>
+<stream>
+<search-result version="0.0">
+<solvable>
+<name>python3</name>
+<version>3.9.0-1.1</version>
+<summary>Python 3 interpreter</summary>
+<arch>x86_64</arch>
+<repository>main-repo</repository>
+<status>not-installed</status>
+<kind>package</kind>
+</solvable>
+<solvable>
+<name>python3-pip</name>
+<version>20.3.4-1.1</version>
+<summary>Python package manager</summary>
+<arch>noarch</arch>
+<repository>main-repo</repository>
+<status>not-installed</status>
+<kind>package</kind>
+</solvable>
+</search-result>
+</stream>"#;
+
+        let packages = ZypperManager::parse_search_xml(xml);
+        assert_eq!(packages.len(), 2);
+        assert_eq!(packages[0].name, "python3");
+        assert_eq!(packages[1].name, "python3-pip");
+    }
+}


### PR DESCRIPTION
## 描述
feat(backend): add Zypper package manager implementation for openSUSE support

Implement PackageManager trait for openSUSE's Zypper package manager with XML output parsing support.

## 变更
- `src/managers/zypper.rs`
- `src/managers/mod.rs`
- `Cargo.toml`

## 测试
- [ ] 本地测试通过
- [ ] CI 检查通过

Closes #57
