### PR TITLE
Feature/zypper manager

### DIFF
--- a/src/managers/mod.rs
+++ b/src/managers/mod.rs
@@ -3,6 +3,7 @@ pub mod arch;
 pub mod brew;
 pub mod pacman;
 pub mod yay;
+pub mod zypper;
 
 use ratatui::DefaultTerminal;
 use std::collections::{HashMap, HashSet};
@@ -189,6 +190,10 @@ pub fn get_available_managers() -> Vec<String> {
         available.push("apt".to_string());
     }
 
+    if std::process::Command::new("which").arg("zypper").output().map(|o| o.status.success()).unwrap_or(false) {
+        available.push("zypper".to_string());
+    }
+
     available
 }
 
@@ -209,6 +214,10 @@ pub fn get_system_manager(config: &crate::config::Config) -> Box<dyn PackageMana
 
     if available.contains(&"apt".to_string()) && enabled.contains(&"apt".to_string()) {
         managers.push(Box::new(apt::AptManager));
+    }
+
+    if available.contains(&"zypper".to_string()) && enabled.contains(&"zypper".to_string()) {
+        managers.push(Box::new(zypper::ZypperManager));
     }
 
     if managers.is_empty() {
@@ -267,4 +276,20 @@ pub fn parse_alternating_lines(lines: &[&str], manager: String, query: &str) -> 
     res.sort_by(|a, b| b.score.partial_cmp(&a.score).unwrap_or(std::cmp::Ordering::Equal));
 
     res
+}
+
+pub fn manager_handles_provider(manager_name: &str, provider: &str) -> bool {
+    let m_lower = manager_name.to_lowercase();
+    let p_lower = provider.to_lowercase();
+    if p_lower.contains("pacman") || p_lower.contains("aur") || p_lower.contains("yay") {
+        m_lower.contains("arch") || m_lower.contains("pacman") || m_lower.contains("yay")
+    } else if p_lower.contains("brew") || p_lower.contains("homebrew") {
+        m_lower.contains("brew")
+    } else if p_lower.contains("apt") {
+        m_lower.contains("apt") || m_lower.contains("debian") || m_lower.contains("ubuntu")
+    } else if p_lower.contains("zypper") || p_lower.contains("opensuse") || p_lower.contains("suse") {
+        m_lower.contains("zypper") || m_lower.contains("opensuse") || m_lower.contains("suse")
+    } else {
+        p_lower.contains(&m_lower) || m_lower.contains(&p_lower)
+    }
 }

--- a/src/managers/mod.rs
+++ b/src/managers/mod.rs
@@ -190,6 +190,9 @@ pub fn get_available_managers() -> Vec<String> {
         available.push("apt".to_string());
     }
 
+    // Zypper does not have a reliable quick exit like `--version` that 
+    // doesn't potentially trigger a slow refresh or output verbose messages.
+    // So we check for its presence in PATH via `which zypper` as the safest and fastest methodology.
     if std::process::Command::new("which").arg("zypper").output().map(|o| o.status.success()).unwrap_or(false) {
         available.push("zypper".to_string());
     }

--- a/src/managers/mod.rs
+++ b/src/managers/mod.rs
@@ -191,7 +191,12 @@ pub fn get_available_managers() -> Vec<String> {
     // Zypper does not have a reliable quick exit like `--version` that 
     // doesn't potentially trigger a slow refresh or output verbose messages.
     // So we check for its presence in PATH via `which zypper` as the safest and fastest methodology.
-    if std::process::Command::new("which").arg("zypper").output().map(|o| o.status.success()).unwrap_or(false) {
+    if std::process::Command::new("which")
+        .arg("zypper")
+        .output()
+        .map(|o| o.status.success())
+        .unwrap_or(false)
+    {
         available.push("zypper".to_string());
     }
 
@@ -288,7 +293,8 @@ pub fn manager_handles_provider(manager_name: &str, provider: &str) -> bool {
         m_lower.contains("brew")
     } else if p_lower.contains("apt") {
         m_lower.contains("apt") || m_lower.contains("debian") || m_lower.contains("ubuntu")
-    } else if p_lower.contains("zypper") || p_lower.contains("opensuse") || p_lower.contains("suse") {
+    } else if p_lower.contains("zypper") || p_lower.contains("opensuse") || p_lower.contains("suse")
+    {
         m_lower.contains("zypper") || m_lower.contains("opensuse") || m_lower.contains("suse")
     } else {
         p_lower.contains(&m_lower) || m_lower.contains(&p_lower)

--- a/src/managers/mod.rs
+++ b/src/managers/mod.rs
@@ -188,7 +188,7 @@ pub fn get_available_managers() -> Vec<String> {
         available.push("apt".to_string());
     }
 
-    // Zypper does not have a reliable quick exit like `--version` that 
+    // Zypper does not have a reliable quick exit like `--version` that
     // doesn't potentially trigger a slow refresh or output verbose messages.
     // So we check for its presence in PATH via `which zypper` as the safest and fastest methodology.
     if std::process::Command::new("which")

--- a/src/managers/mod.rs
+++ b/src/managers/mod.rs
@@ -95,9 +95,7 @@ impl PackageManager for CombinedManager {
     fn get_details(&self, pkg: &str, provider: &str) -> Option<HashMap<String, String>> {
         for m in &self.managers {
             // Check if this manager's name/prefix matches the provider
-            if provider.to_lowercase().contains(&m.name().to_lowercase())
-                || m.name().to_lowercase().contains(&provider.to_lowercase())
-            {
+            if manager_handles_provider(m.name(), provider) {
                 return m.get_details(pkg, provider);
             }
         }

--- a/src/managers/zypper.rs
+++ b/src/managers/zypper.rs
@@ -221,18 +221,13 @@ impl PackageManager for ZypperManager {
     fn install(
         &self,
         terminal: &mut DefaultTerminal,
-        pkgs: &HashSet<(String, String)>,
+        pkgs: &HashSet<String>,
     ) -> Result<(), Box<dyn std::error::Error>> {
-        let names: HashSet<String> = pkgs
-            .iter()
-            .filter(|(_, provider)| super::manager_handles_provider(self.name(), provider))
-            .map(|(name, _)| name.clone())
-            .collect();
-        if names.is_empty() {
+        if pkgs.is_empty() {
             return Ok(());
         }
         let mut args = vec!["zypper", "install", "-y"];
-        let pkg_refs: Vec<&str> = names.iter().map(|s| s.as_str()).collect();
+        let pkg_refs: Vec<&str> = pkgs.iter().map(|s| s.as_str()).collect();
         args.extend(pkg_refs);
         crate::execute_external_command(terminal, "sudo", &args)?;
         Ok(())
@@ -244,18 +239,13 @@ impl PackageManager for ZypperManager {
     fn remove(
         &self,
         terminal: &mut DefaultTerminal,
-        pkgs: &HashSet<(String, String)>,
+        pkgs: &HashSet<String>,
     ) -> Result<(), Box<dyn std::error::Error>> {
-        let names: HashSet<String> = pkgs
-            .iter()
-            .filter(|(_, provider)| super::manager_handles_provider(self.name(), provider))
-            .map(|(name, _)| name.clone())
-            .collect();
-        if names.is_empty() {
+        if pkgs.is_empty() {
             return Ok(());
         }
         let mut args = vec!["zypper", "remove", "-y"];
-        let pkg_refs: Vec<&str> = names.iter().map(|s| s.as_str()).collect();
+        let pkg_refs: Vec<&str> = pkgs.iter().map(|s| s.as_str()).collect();
         args.extend(pkg_refs);
         crate::execute_external_command(terminal, "sudo", &args)?;
         Ok(())
@@ -267,18 +257,13 @@ impl PackageManager for ZypperManager {
     fn update_packages(
         &self,
         terminal: &mut DefaultTerminal,
-        pkgs: &HashSet<(String, String)>,
+        pkgs: &HashSet<String>,
     ) -> Result<(), Box<dyn std::error::Error>> {
-        let names: HashSet<String> = pkgs
-            .iter()
-            .filter(|(_, provider)| super::manager_handles_provider(self.name(), provider))
-            .map(|(name, _)| name.clone())
-            .collect();
-        if names.is_empty() {
+        if pkgs.is_empty() {
             return Ok(());
         }
         let mut args = vec!["zypper", "update", "-y"];
-        let pkg_refs: Vec<&str> = names.iter().map(|s| s.as_str()).collect();
+        let pkg_refs: Vec<&str> = pkgs.iter().map(|s| s.as_str()).collect();
         args.extend(pkg_refs);
         crate::execute_external_command(terminal, "sudo", &args)?;
         Ok(())

--- a/src/managers/zypper.rs
+++ b/src/managers/zypper.rs
@@ -15,7 +15,7 @@ fn parse_xml_solvables(xml: &str, provider: &str, query: &str) -> Vec<Package> {
 
     for line in xml.lines() {
         let line = line.trim();
-        if !line.starts_with("<solvable ") {
+        if !line.starts_with("<solvable ") && !line.starts_with("<update ") {
             continue;
         }
 
@@ -48,14 +48,14 @@ fn parse_xml_solvables(xml: &str, provider: &str, query: &str) -> Vec<Package> {
 /// Minimal attribute extractor for zypper XML (avoids a full XML parser dependency).
 /// Handles both single- and double-quoted attribute values.
 fn extract_xml_attr<'a>(line: &'a str, attr: &str) -> Option<String> {
-    let needle = format!("{}=\"", attr);
+    let needle = format!(" {}=\"", attr);
     if let Some(start) = line.find(&needle) {
         let rest = &line[start + needle.len()..];
         let end = rest.find('"')?;
         return Some(rest[..end].to_string());
     }
     // Try single-quoted variant
-    let needle_sq = format!("{}='", attr);
+    let needle_sq = format!(" {}='", attr);
     if let Some(start) = line.find(&needle_sq) {
         let rest = &line[start + needle_sq.len()..];
         let end = rest.find('\'')?;

--- a/src/managers/zypper.rs
+++ b/src/managers/zypper.rs
@@ -1,0 +1,308 @@
+use crate::managers::{Package, PackageManager};
+use ratatui::DefaultTerminal;
+use std::collections::{HashMap, HashSet};
+use std::process::Command;
+
+pub struct ZypperManager;
+
+/// Parse zypper XML output for `search` and `packages` commands.
+/// Zypper XML search results have the form:
+/// ```xml
+/// <solvable name="vim" kind="package" edition="9.1" arch="x86_64" summary="Vi IMproved"/>
+/// ```
+fn parse_xml_solvables(xml: &str, provider: &str, query: &str) -> Vec<Package> {
+    let mut packages = Vec::new();
+
+    for line in xml.lines() {
+        let line = line.trim();
+        if !line.starts_with("<solvable ") {
+            continue;
+        }
+
+        let name = extract_xml_attr(line, "name").unwrap_or_default();
+        let edition = extract_xml_attr(line, "edition").unwrap_or_default();
+        let summary = extract_xml_attr(line, "summary").unwrap_or_default();
+
+        if name.is_empty() {
+            continue;
+        }
+
+        let score = if query.is_empty() {
+            1.0
+        } else {
+            crate::fuzzy::fuzzy_match(query, &name)
+        };
+
+        packages.push(Package {
+            provider: provider.to_string(),
+            name,
+            version: edition,
+            description: summary,
+            score,
+        });
+    }
+
+    packages
+}
+
+/// Minimal attribute extractor for zypper XML (avoids a full XML parser dependency).
+/// Handles both single- and double-quoted attribute values.
+fn extract_xml_attr<'a>(line: &'a str, attr: &str) -> Option<String> {
+    let needle = format!("{}=\"", attr);
+    if let Some(start) = line.find(&needle) {
+        let rest = &line[start + needle.len()..];
+        let end = rest.find('"')?;
+        return Some(rest[..end].to_string());
+    }
+    // Try single-quoted variant
+    let needle_sq = format!("{}='", attr);
+    if let Some(start) = line.find(&needle_sq) {
+        let rest = &line[start + needle_sq.len()..];
+        let end = rest.find('\'')?;
+        return Some(rest[..end].to_string());
+    }
+    None
+}
+
+impl PackageManager for ZypperManager {
+    fn name(&self) -> &str {
+        "Zypper (openSUSE)"
+    }
+
+    // -------------------------------------------------------------------------
+    // search
+    // -------------------------------------------------------------------------
+    fn search(&self, query: &str) -> Vec<Package> {
+        if query.is_empty() {
+            return Vec::new();
+        }
+
+        // Check cache
+        {
+            let cache = crate::managers::SEARCH_CACHE.lock().unwrap();
+            if let Some(cached) = cache.get(query) {
+                return cached.clone();
+            }
+        }
+
+        let output = Command::new("zypper")
+            .args(["--xmlout", "search", query])
+            .output()
+            .ok();
+
+        let mut packages = if let Some(out) = output {
+            // zypper exits with 0 (no results) or non-zero on real errors;
+            // any XML in stdout is still valid regardless of exit code here.
+            let xml = String::from_utf8_lossy(&out.stdout);
+            let mut pkgs = parse_xml_solvables(&xml, "zypper", query);
+            pkgs.retain(|p| p.score > 0.01);
+            pkgs.sort_by(|a, b| b.score.partial_cmp(&a.score).unwrap_or(std::cmp::Ordering::Equal));
+            pkgs
+        } else {
+            Vec::new()
+        };
+
+        let config = crate::config::Config::load();
+        packages.truncate(config.settings.max_search_results);
+
+        // Update cache
+        {
+            let mut cache = crate::managers::SEARCH_CACHE.lock().unwrap();
+            cache.insert(query.to_string(), packages.clone());
+        }
+
+        packages
+    }
+
+    // -------------------------------------------------------------------------
+    // get_installed  (names only, used for highlighting)
+    // -------------------------------------------------------------------------
+    fn get_installed(&self) -> HashSet<String> {
+        let output = Command::new("zypper")
+            .args(["--xmlout", "packages", "--installed-only"])
+            .output()
+            .ok();
+
+        if let Some(out) = output {
+            let xml = String::from_utf8_lossy(&out.stdout);
+            parse_xml_solvables(&xml, "zypper", "")
+                .into_iter()
+                .map(|p| p.name)
+                .collect()
+        } else {
+            HashSet::new()
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // get_installed_details
+    // -------------------------------------------------------------------------
+    fn get_installed_details(&self) -> Vec<Package> {
+        let output = Command::new("zypper")
+            .args(["--xmlout", "packages", "--installed-only"])
+            .output()
+            .ok();
+
+        if let Some(out) = output {
+            let xml = String::from_utf8_lossy(&out.stdout);
+            let mut pkgs = parse_xml_solvables(&xml, "zypper/local", "");
+            pkgs.iter_mut().for_each(|p| p.score = 1.0);
+            pkgs
+        } else {
+            Vec::new()
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // get_updates
+    // Exit code 100 means "updates available" — that is NOT an error for zypper.
+    // -------------------------------------------------------------------------
+    fn get_updates(&self) -> Vec<Package> {
+        let output = Command::new("zypper")
+            .args(["--xmlout", "list-updates"])
+            .output()
+            .ok();
+
+        if let Some(out) = output {
+            // Exit code 100 = updates available (treat like success)
+            let code = out.status.code().unwrap_or(0);
+            if code != 0 && code != 100 {
+                return Vec::new();
+            }
+            let xml = String::from_utf8_lossy(&out.stdout);
+            let mut pkgs = parse_xml_solvables(&xml, "zypper/update", "");
+            pkgs.iter_mut().for_each(|p| {
+                p.score = 1.0;
+                if p.description.is_empty() {
+                    p.description = "Update available".to_string();
+                }
+            });
+            pkgs
+        } else {
+            Vec::new()
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // get_details  (plain-text `info` sub-command; XML info is verbose)
+    // -------------------------------------------------------------------------
+    fn get_details(&self, pkg: &str, _provider: &str) -> Option<HashMap<String, String>> {
+        // Check cache first
+        {
+            let cache = crate::managers::DETAILS_CACHE.lock().unwrap();
+            if let Some(cached) = cache.get(pkg) {
+                return Some(cached.clone());
+            }
+        }
+
+        let pure_name = pkg.split('/').next_back().unwrap_or(pkg);
+
+        let output = Command::new("zypper")
+            .args(["info", pure_name])
+            .output()
+            .ok()?;
+
+        let stdout = String::from_utf8_lossy(&output.stdout).to_string();
+        let mut info = HashMap::new();
+        info.insert("Info".to_string(), stdout);
+
+        // Update cache
+        {
+            let mut cache = crate::managers::DETAILS_CACHE.lock().unwrap();
+            cache.insert(pkg.to_string(), info.clone());
+        }
+
+        Some(info)
+    }
+
+    // -------------------------------------------------------------------------
+    // install
+    // -------------------------------------------------------------------------
+    fn install(
+        &self,
+        terminal: &mut DefaultTerminal,
+        pkgs: &HashSet<(String, String)>,
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        let names: HashSet<String> = pkgs
+            .iter()
+            .filter(|(_, provider)| super::manager_handles_provider(self.name(), provider))
+            .map(|(name, _)| name.clone())
+            .collect();
+        if names.is_empty() {
+            return Ok(());
+        }
+        let mut args = vec!["zypper", "install", "-y"];
+        let pkg_refs: Vec<&str> = names.iter().map(|s| s.as_str()).collect();
+        args.extend(pkg_refs);
+        crate::execute_external_command(terminal, "sudo", &args)?;
+        Ok(())
+    }
+
+    // -------------------------------------------------------------------------
+    // remove
+    // -------------------------------------------------------------------------
+    fn remove(
+        &self,
+        terminal: &mut DefaultTerminal,
+        pkgs: &HashSet<(String, String)>,
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        let names: HashSet<String> = pkgs
+            .iter()
+            .filter(|(_, provider)| super::manager_handles_provider(self.name(), provider))
+            .map(|(name, _)| name.clone())
+            .collect();
+        if names.is_empty() {
+            return Ok(());
+        }
+        let mut args = vec!["zypper", "remove", "-y"];
+        let pkg_refs: Vec<&str> = names.iter().map(|s| s.as_str()).collect();
+        args.extend(pkg_refs);
+        crate::execute_external_command(terminal, "sudo", &args)?;
+        Ok(())
+    }
+
+    // -------------------------------------------------------------------------
+    // update_packages  (install a specific version == upgrade selected pkgs)
+    // -------------------------------------------------------------------------
+    fn update_packages(
+        &self,
+        terminal: &mut DefaultTerminal,
+        pkgs: &HashSet<(String, String)>,
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        let names: HashSet<String> = pkgs
+            .iter()
+            .filter(|(_, provider)| super::manager_handles_provider(self.name(), provider))
+            .map(|(name, _)| name.clone())
+            .collect();
+        if names.is_empty() {
+            return Ok(());
+        }
+        let mut args = vec!["zypper", "update", "-y"];
+        let pkg_refs: Vec<&str> = names.iter().map(|s| s.as_str()).collect();
+        args.extend(pkg_refs);
+        crate::execute_external_command(terminal, "sudo", &args)?;
+        Ok(())
+    }
+
+    // -------------------------------------------------------------------------
+    // system_upgrade  →  zypper dup  (distribution upgrade)
+    // -------------------------------------------------------------------------
+    fn system_upgrade(
+        &self,
+        terminal: &mut DefaultTerminal,
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        crate::execute_external_command(terminal, "sudo", &["zypper", "dup", "-y"])?;
+        Ok(())
+    }
+
+    // -------------------------------------------------------------------------
+    // refresh_databases  →  zypper refresh
+    // -------------------------------------------------------------------------
+    fn refresh_databases(
+        &self,
+        terminal: &mut DefaultTerminal,
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        crate::execute_external_command(terminal, "sudo", &["zypper", "refresh"])?;
+        Ok(())
+    }
+}

--- a/src/managers/zypper.rs
+++ b/src/managers/zypper.rs
@@ -27,11 +27,7 @@ fn parse_xml_solvables(xml: &str, provider: &str, query: &str) -> Vec<Package> {
             continue;
         }
 
-        let score = if query.is_empty() {
-            1.0
-        } else {
-            crate::fuzzy::fuzzy_match(query, &name)
-        };
+        let score = if query.is_empty() { 1.0 } else { crate::fuzzy::fuzzy_match(query, &name) };
 
         packages.push(Package {
             provider: provider.to_string(),
@@ -85,10 +81,7 @@ impl PackageManager for ZypperManager {
             }
         }
 
-        let output = Command::new("zypper")
-            .args(["--xmlout", "search", query])
-            .output()
-            .ok();
+        let output = Command::new("zypper").args(["--xmlout", "search", query]).output().ok();
 
         let mut packages = if let Some(out) = output {
             // zypper exits with 0 (no results) or non-zero on real errors;
@@ -118,17 +111,11 @@ impl PackageManager for ZypperManager {
     // get_installed  (names only, used for highlighting)
     // -------------------------------------------------------------------------
     fn get_installed(&self) -> HashSet<String> {
-        let output = Command::new("zypper")
-            .args(["--xmlout", "search", "-i"])
-            .output()
-            .ok();
+        let output = Command::new("zypper").args(["--xmlout", "search", "-i"]).output().ok();
 
         if let Some(out) = output {
             let xml = String::from_utf8_lossy(&out.stdout);
-            parse_xml_solvables(&xml, "zypper", "")
-                .into_iter()
-                .map(|p| p.name)
-                .collect()
+            parse_xml_solvables(&xml, "zypper", "").into_iter().map(|p| p.name).collect()
         } else {
             HashSet::new()
         }
@@ -138,10 +125,7 @@ impl PackageManager for ZypperManager {
     // get_installed_details
     // -------------------------------------------------------------------------
     fn get_installed_details(&self) -> Vec<Package> {
-        let output = Command::new("zypper")
-            .args(["--xmlout", "search", "-i"])
-            .output()
-            .ok();
+        let output = Command::new("zypper").args(["--xmlout", "search", "-i"]).output().ok();
 
         if let Some(out) = output {
             let xml = String::from_utf8_lossy(&out.stdout);
@@ -158,10 +142,7 @@ impl PackageManager for ZypperManager {
     // Exit code 100 means "updates available" — that is NOT an error for zypper.
     // -------------------------------------------------------------------------
     fn get_updates(&self) -> Vec<Package> {
-        let output = Command::new("zypper")
-            .args(["--xmlout", "list-updates"])
-            .output()
-            .ok();
+        let output = Command::new("zypper").args(["--xmlout", "list-updates"]).output().ok();
 
         if let Some(out) = output {
             // Exit code 100 = updates available (treat like success)
@@ -197,10 +178,7 @@ impl PackageManager for ZypperManager {
 
         let pure_name = pkg.split('/').next_back().unwrap_or(pkg);
 
-        let output = Command::new("zypper")
-            .args(["info", pure_name])
-            .output()
-            .ok()?;
+        let output = Command::new("zypper").args(["info", pure_name]).output().ok()?;
 
         let stdout = String::from_utf8_lossy(&output.stdout).to_string();
         let mut info = HashMap::new();

--- a/src/managers/zypper.rs
+++ b/src/managers/zypper.rs
@@ -119,7 +119,7 @@ impl PackageManager for ZypperManager {
     // -------------------------------------------------------------------------
     fn get_installed(&self) -> HashSet<String> {
         let output = Command::new("zypper")
-            .args(["--xmlout", "packages", "--installed-only"])
+            .args(["--xmlout", "search", "-i"])
             .output()
             .ok();
 
@@ -139,7 +139,7 @@ impl PackageManager for ZypperManager {
     // -------------------------------------------------------------------------
     fn get_installed_details(&self) -> Vec<Package> {
         let output = Command::new("zypper")
-            .args(["--xmlout", "packages", "--installed-only"])
+            .args(["--xmlout", "search", "-i"])
             .output()
             .ok();
 


### PR DESCRIPTION
## Description
Adds native Zypper package manager support for openSUSE Leap and Tumbleweed users.

Fixes #57

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?
- [x] Manual test (please describe)
  - Verified all trait methods compile and match the signatures of existing managers (apt, arch, brew)
  - XML attribute extractor validated against `zypper --xmlout search` sample output
  - Exit code 100 handling for `list-updates` confirmed against zypper documentation
- [ ] `cargo test`

## Checklist:
- [x] My code follows the [Coding Guidelines](CONTRIBUTING.md#4-coding-guidelines).
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have NOT added useless AI-generated comments.
- [x] I have NOT deleted existing unrelated comments.
- [x] I have NOT modified files unrelated to this task.
- [ ] I have included screenshots/recordings (for UI changes).
- [x] My changes generate no new warnings (clippy/fmt).
- [x] I have linked the issue I am working on.

## Screenshots (if applicable)
<img width="1903" height="970" alt="image" src="https://github.com/user-attachments/assets/a7bfd166-0b64-493f-a012-34f0765672c2" />

<img width="1671" height="862" alt="Screenshot 2026-06-11 032846" src="https://github.com/user-attachments/assets/2c144593-1564-45e1-a0f4-80f5753d5a80" />

<img width="1718" height="853" alt="Screenshot 2026-06-11 033236" src="https://github.com/user-attachments/assets/3e5341c1-9a0f-431b-9f34-29b941b07f4c" />
